### PR TITLE
Fix Serialisation

### DIFF
--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1.1",
+    "version": "1.2",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/ABPlcRx/ABPlcRx.csproj
+++ b/src/ABPlcRx/ABPlcRx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/ABPlcRx/Core/PlcTagException.cs
+++ b/src/ABPlcRx/Core/PlcTagException.cs
@@ -12,7 +12,7 @@ namespace ABPlcRx;
 /// Initializes a new instance of the <see cref="PlcTagException"/> class.
 /// </remarks>
 /// <param name="result">The result.</param>
-[System.Serializable]
+[Serializable]
 #pragma warning disable RCS1194 // Implement exception constructors.
 public class PlcTagException(PlcTagResult result) : Exception("Error executing PlcTag operation.")
 #pragma warning restore RCS1194 // Implement exception constructors.

--- a/src/ABPlcRx/Core/PlcTagResult.cs
+++ b/src/ABPlcRx/Core/PlcTagResult.cs
@@ -6,6 +6,7 @@ namespace ABPlcRx;
 /// <summary>
 /// Plc Tag Result.
 /// </summary>
+[Serializable]
 public class PlcTagResult
 {
     internal PlcTagResult(IPlcTag tag, DateTime timestamp, long executionTime, int statusCode)


### PR DESCRIPTION
This pull request includes several updates to the project version, target frameworks, and attributes for exception handling. The changes aim to improve compatibility and serialization support.

Versioning and Target Frameworks:

* [`Version.json`](diffhunk://#diff-0826772c687c7936b7dbce71a16169011b0bb06f3afaca72c872f7e2d689926cL3-R3): Updated the project version from `1.1.1` to `1.2`.
* [`src/ABPlcRx/ABPlcRx.csproj`](diffhunk://#diff-45ed90818e19126e7562c4dbd3886bda55bdc1e9b396b6667ba6922ad3ea8f4fL4-R4): Changed target frameworks to `netstandard2.0`, `net8.0`, and `net9.0`, removing `net6.0` and `net7.0`.

Serialization Attributes:

* [`src/ABPlcRx/Core/PlcTagException.cs`](diffhunk://#diff-b58257e680f96b8255ba4ae8ba6ca4c261008f247aa35e1fc56aed3c483d0f65L15-R15): Replaced `[System.Serializable]` with `[Serializable]` for the `PlcTagException` class.
* [`src/ABPlcRx/Core/PlcTagResult.cs`](diffhunk://#diff-3b5a747243ffdb24101639ed39b92361c54f15adc3f102ff90824309d50479fbR9): Added `[Serializable]` attribute to the `PlcTagResult` class.