### PR TITLE
Update Roslynator Analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,7 +54,7 @@
   <ItemGroup>
     <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.10.0" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/src/ABPlcRx/ABPlcRx.cs
+++ b/src/ABPlcRx/ABPlcRx.cs
@@ -11,7 +11,7 @@ namespace ABPlcRx;
 /// </summary>
 public class ABPlcRx : IABPlcRx
 {
-    private readonly CompositeDisposable _disposables = new();
+    private readonly CompositeDisposable _disposables = [];
     private readonly ABPlc _plc;
     private readonly TimeSpan _scanInterval;
     private bool _scanEnabled;

--- a/src/ABPlcRx/Core/DataLength.cs
+++ b/src/ABPlcRx/Core/DataLength.cs
@@ -109,8 +109,7 @@ internal static class DataLength
         else if (!NativeTypes.TryGetValue(type, out size) && type.IsClass && !type.IsAbstract)
         {
             size += TagHelper.GetAccessableProperties(type)
-                             .Select(a => GetSizeObject(a.GetValue(obj)))
-                             .Sum();
+                             .Sum(a => GetSizeObject(a.GetValue(obj)));
         }
 
         return size;

--- a/src/ABPlcRx/Core/PlcTagCollection.cs
+++ b/src/ABPlcRx/Core/PlcTagCollection.cs
@@ -159,7 +159,7 @@ internal class PlcTagCollection : IDisposable
     /// Performs read of Group of Tags.
     /// </summary>
     /// <returns>A Value.</returns>
-    public IEnumerable<PlcTagResult> Read() => Tags.Select(a => a.Read()).ToArray();
+    public IEnumerable<PlcTagResult> Read() => [.. Tags.Select(a => a.Read())];
 
     /// <summary>
     /// Remove tag.
@@ -186,10 +186,7 @@ internal class PlcTagCollection : IDisposable
     /// Performs write of Group of Tags.
     /// </summary>
     /// <returns>A Value.</returns>
-    public IEnumerable<PlcTagResult> Write()
-    {
-        return Tags.Select(a => a.Write());
-    }
+    public IEnumerable<PlcTagResult> Write() => Tags.Select(a => a.Write());
 
     /// <summary>
     /// Releases unmanaged and - optionally - managed resources.

--- a/src/ABPlcRx/Core/PlcTagWrapper.cs
+++ b/src/ABPlcRx/Core/PlcTagWrapper.cs
@@ -29,19 +29,19 @@ public class PlcTagWrapper
     /// Get bit array from value.
     /// </summary>
     /// <returns>A Value.</returns>
-    public BitArray GetBits() => new(new[] { Convert.ToInt32(GetNumericValue()) });
+    public BitArray GetBits() => new([Convert.ToInt32(GetNumericValue())]);
 
     /// <summary>
     /// Get bit array from value.
     /// </summary>
     /// <returns>A Value.</returns>
-    public bool[] GetBitsArray() => GetBits().Cast<bool>().ToArray();
+    public bool[] GetBitsArray() => [.. GetBits().Cast<bool>()];
 
     /// <summary>
     /// Get bit string format.
     /// </summary>
     /// <returns>A Value.</returns>
-    public string GetBitsString() => new(GetBits().Cast<bool>().Select(a => a ? '1' : '0').ToArray());
+    public string GetBitsString() => new([.. GetBits().Cast<bool>().Select(a => a ? '1' : '0')]);
 
     /// <summary>
     /// Get local value Float32.


### PR DESCRIPTION
This pull request includes several changes to improve code readability and update dependencies. The most important changes involve updating package references, modifying how collections are initialized, and refactoring methods for better readability.

### Dependency Updates:
* Updated `Roslynator.Analyzers` package reference from version `4.10.0` to `4.13.1` in `Directory.Build.props` to ensure compatibility with the latest features and fixes.

### Code Readability Improvements:
* Changed the initialization of `_disposables` from `new()` to `[]` in the `ABPlcRx` class to use a more concise syntax.
* Refactored the `GetSizeObject` method in `DataLength.cs` to use a more readable `Sum` method call.
* Simplified the `Read` method in the `PlcTagCollection` class by using the new collection initialization syntax.
* Refactored the `Write` method in the `PlcTagCollection` class to a single line expression for improved readability.
* Updated the `PlcTagWrapper` class methods to use the new collection initialization syntax for better readability.