### PR TITLE
Add source generator and async observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,23 @@ Supported PLC families (via libplctag)
 Core features
 - Create tags and group them for bulk operations
 - Reactive APIs (IObservable) for on‑change updates
+- Async reactive APIs (IObservableAsync) through ReactiveUI.Extensions on .NET 8+
 - Read/write primitives: 8/16/32/64‑bit signed/unsigned, 32/64‑bit float
 - Bit addressing helpers for coil/word bits
 - String and structure support (libplctag style)
 - Bulk read/write across groups
 - Health monitoring (Ping/ObservePing)
+- Source generator attributes for typed PLC stream models
+- TUnit tests running on Microsoft Testing Platform
 
 Getting started
 Installation
 - Install the NuGet package:
   - Package Manager: Install-Package ABPlcRx
   - .NET CLI: dotnet add package ABPlcRx
+- To generate typed stream models, add the source generator package/project as an analyzer:
+  - Package Manager: Install-Package ABPlcRx.SourceGenerators
+  - .NET CLI: dotnet add package ABPlcRx.SourceGenerators
 - ABPlcRx depends on libplctag; the NuGet dependency brings required bindings.
 
 Basic concepts
@@ -88,11 +94,54 @@ glx.Value("Counter", lgx.Value<int>("Counter") + 1);
 
 Reactive API highlights
 - Observe<T>(variable, bit = -1): stream values on change, supports late‑added tags
+- ObserveAsync<T>(variable, bit = -1): async-native stream using ReactiveUI.Extensions.Async on .NET 8+
 - ObserveMany(params string[] variables): latest values as a dictionary
+- ObserveManyAsync(params string[] variables): async-native latest value dictionaries
 - ObserveGroup(groupName): emits tag objects in a group when they change
+- ObserveGroupAsync(groupName): async-native group stream
 - ObserveSampled<T>(variable, sampleInterval, bit, scheduler): sampled stream for rate limiting
+- ObserveSampledAsync<T>(variable, sampleInterval, bit, scheduler): async-native sampled stream
 - ObserveErrors(): only tag operations that returned an error
+- ObserveErrorsAsync(): async-native error stream
 - CreateWriter<T>(variable, bit): returns an IObserver<T> that writes on OnNext
+
+Async observables
+```csharp
+using ReactiveUI.Extensions.Async;
+
+var counter = lgx.ObserveAsync<int>("Counter");
+
+// IObservableAsync<T> can use ReactiveUI.Extensions.Async operators,
+// including Select, Where, Merge, CombineLatest, Retry, Timeout, Publish,
+// ReplayLatest, ToObservable, and ToObservableAsync.
+var activeCounter =
+    counter
+        .Where(value => value > 0)
+        .Select(value => $"Counter={value}");
+```
+
+Source generated stream models
+```csharp
+using ABPlcRx.SourceGeneration;
+
+[PlcModel]
+[PlcTag(typeof(int), "Counter", "MyDINT")]
+[PlcTag(typeof(bool), "LightOn", "B3:3", Bit = 0)]
+public partial class MachineTags
+{
+}
+
+var tags = new MachineTags();
+using var binding = tags.AttachPlcStreams(slc);
+
+tags.CounterObservable.Subscribe(value => Console.WriteLine($"Counter={value}"));
+tags.LightOnObservable.Subscribe(value => Console.WriteLine($"LightOn={value}"));
+
+// On .NET 8+ the generator also emits IObservableAsync<T> streams.
+var asyncLightOn = tags.LightOnObservableAsync;
+```
+
+The generator creates a property for each class-level `PlcTag` attribute, registers tags in `AttachPlcStreams`, keeps the generated property updated from the observable subscription, and exposes both `PropertyNameObservable` and `PropertyNameObservableAsync` on .NET 8+. Boolean bit tags are registered as `short` tags and exposed as `bool` values.
 
 Examples
 Observe multiple variables
@@ -139,14 +188,28 @@ API surface (high level)
 - ABPlcRx (implements IABPlcRx)
   - AddUpdateTagItem<T>(variable, tagName, tagGroup = "Default")
   - Observe<T>(variable, bit = -1)
+  - ObserveAsync<T>(variable, bit = -1) on .NET 8+
   - ObserveMany(params string[] variables)
+  - ObserveManyAsync(params string[] variables) on .NET 8+
   - ObserveGroup(groupName)
+  - ObserveGroupAsync(groupName) on .NET 8+
   - ObserveSampled<T>(variable, sampleInterval, bit = -1, scheduler = null)
+  - ObserveSampledAsync<T>(variable, sampleInterval, bit = -1, scheduler = null) on .NET 8+
   - ObserveErrors()
+  - ObserveErrorsAsync() on .NET 8+
   - CreateWriter<T>(variable, bit = -1)
   - Value<T>(variable, bit = -1) / Value<T>(variable, value, bit = -1)
   - Read()/Read(variable) and Write()/Write(variable)
   - Ping(bool echo = false), PingAsync(...), ObservePing(interval,...)
+  - ObservePingAsync(interval,...) on .NET 8+
+
+Testing
+- Tests are in `src/ABPlcRx.Tests`.
+- The suite uses TUnit with Microsoft Testing Platform; `global.json` sets `"test": { "runner": "Microsoft.Testing.Platform" }`.
+- Run all tests with:
+```bash
+dotnet test src/ABPlcRx.sln
+```
 
 Data types and bit access
 - To treat a single bit as a boolean, create the tag as `short` and use the `bit` parameter (0‑15).

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.101",
     "rollForward": "latestFeature",
     "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/ABPlcRx.SourceGenerators/ABPlcRx.SourceGenerators.csproj
+++ b/src/ABPlcRx.SourceGenerators/ABPlcRx.SourceGenerators.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <PackageDescription>Source generators for ABPlcRx reactive PLC stream models.</PackageDescription>
+    <PackageTags>ABPlcRx;source-generator;reactive;PLC;observable</PackageTags>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>$(NoWarn);RCS1197;RCS1201;RS1035;RS1042</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/ABPlcRx.SourceGenerators/PlcModelGenerator.cs
+++ b/src/ABPlcRx.SourceGenerators/PlcModelGenerator.cs
@@ -1,0 +1,468 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ABPlcRx.SourceGenerators;
+
+/// <summary>
+/// Generates reactive PLC stream models from ABPlcRx source generation attributes.
+/// </summary>
+[Generator]
+public sealed class PlcModelGenerator : ISourceGenerator
+{
+    private const string PlcModelAttributeName = "ABPlcRx.SourceGeneration.PlcModelAttribute";
+    private const string PlcTagAttributeName = "ABPlcRx.SourceGeneration.PlcTagAttribute";
+
+    /// <inheritdoc/>
+    public void Initialize(GeneratorInitializationContext context) =>
+        context.RegisterForSyntaxNotifications(static () => new Receiver());
+
+    /// <inheritdoc/>
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.SyntaxReceiver is not Receiver receiver)
+        {
+            return;
+        }
+
+        foreach (var declaration in receiver.Candidates)
+        {
+            var semanticModel = context.Compilation.GetSemanticModel(declaration.SyntaxTree);
+            if (semanticModel.GetDeclaredSymbol(declaration, context.CancellationToken) is not INamedTypeSymbol typeSymbol)
+            {
+                continue;
+            }
+
+            var tags = CollectTags(typeSymbol);
+            if (tags.Length == 0 && !HasAttribute(typeSymbol.GetAttributes(), PlcModelAttributeName))
+            {
+                continue;
+            }
+
+            if (!IsPartial(declaration))
+            {
+                ReportPartialRequired(context, declaration, typeSymbol);
+                continue;
+            }
+
+            if (tags.Length == 0)
+            {
+                continue;
+            }
+
+            var source = GenerateModel(typeSymbol, tags);
+            context.AddSource($"{GetSafeHintName(typeSymbol)}.ABPlcRx.g.cs", SourceText.From(source, Encoding.UTF8));
+        }
+    }
+
+    private static ImmutableArray<TagModel> CollectTags(INamedTypeSymbol typeSymbol)
+    {
+        var builder = ImmutableArray.CreateBuilder<TagModel>();
+
+        foreach (var attribute in typeSymbol.GetAttributes().Where(static x => IsAttribute(x, PlcTagAttributeName)))
+        {
+            if (TryCreateClassTag(attribute, out var tag))
+            {
+                builder.Add(tag);
+            }
+        }
+
+        foreach (var property in typeSymbol.GetMembers().OfType<IPropertySymbol>())
+        {
+            foreach (var attribute in property.GetAttributes().Where(static x => IsAttribute(x, PlcTagAttributeName)))
+            {
+                if (TryCreatePropertyTag(property, attribute, out var tag))
+                {
+                    builder.Add(tag);
+                }
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool TryCreateClassTag(AttributeData attribute, out TagModel tag)
+    {
+        tag = default;
+        if (attribute.ConstructorArguments.Length != 3 ||
+            attribute.ConstructorArguments[0].Value is not ITypeSymbol valueType ||
+            attribute.ConstructorArguments[1].Value is not string propertyName ||
+            attribute.ConstructorArguments[2].Value is not string tagName ||
+            string.IsNullOrWhiteSpace(propertyName) ||
+            string.IsNullOrWhiteSpace(tagName))
+        {
+            return false;
+        }
+
+        var settings = ReadSettings(attribute, propertyName);
+        tag = new TagModel(
+            propertyName,
+            settings.Variable,
+            tagName,
+            settings.Group,
+            GetObserveType(valueType),
+            GetObserveType(valueType),
+            IsBoolean(valueType) ? "short" : GetObserveType(valueType),
+            settings.Bit,
+            settings.RegisterTag,
+            generateProperty: true,
+            requiresValueGetOrDefault: false);
+        return true;
+    }
+
+    private static bool TryCreatePropertyTag(IPropertySymbol property, AttributeData attribute, out TagModel tag)
+    {
+        tag = default;
+        if (attribute.ConstructorArguments.Length == 0 ||
+            attribute.ConstructorArguments[0].Value is not string tagName ||
+            string.IsNullOrWhiteSpace(tagName))
+        {
+            return false;
+        }
+
+        var settings = ReadSettings(attribute, property.Name);
+        var valueType = GetNullableUnderlyingType(property.Type) ?? property.Type;
+        tag = new TagModel(
+            property.Name,
+            settings.Variable,
+            tagName,
+            settings.Group,
+            GetObserveType(valueType),
+            property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            IsBoolean(valueType) ? "short" : GetObserveType(valueType),
+            settings.Bit,
+            settings.RegisterTag,
+            generateProperty: false,
+            requiresValueGetOrDefault: false);
+        return true;
+    }
+
+    private static TagSettings ReadSettings(AttributeData attribute, string propertyName)
+    {
+        var variable = propertyName;
+        var group = "Default";
+        var bit = -1;
+        var registerTag = true;
+
+        foreach (var namedArgument in attribute.NamedArguments)
+        {
+            switch (namedArgument.Key)
+            {
+                case "Variable" when namedArgument.Value.Value is string value && !string.IsNullOrWhiteSpace(value):
+                    variable = value;
+                    break;
+                case "Group" when namedArgument.Value.Value is string value && !string.IsNullOrWhiteSpace(value):
+                    group = value;
+                    break;
+                case "Bit" when namedArgument.Value.Value is int value:
+                    bit = value;
+                    break;
+                case "RegisterTag" when namedArgument.Value.Value is bool value:
+                    registerTag = value;
+                    break;
+            }
+        }
+
+        return new TagSettings(variable, group, bit, registerTag);
+    }
+
+    private static string GenerateModel(INamedTypeSymbol typeSymbol, ImmutableArray<TagModel> tags)
+    {
+        var builder = new StringBuilder();
+        var namespaceName = typeSymbol.ContainingNamespace.IsGlobalNamespace ? null : typeSymbol.ContainingNamespace.ToDisplayString();
+
+        builder.AppendLine("// <auto-generated />");
+        builder.AppendLine("#nullable enable");
+        builder.AppendLine("using System;");
+        builder.AppendLine("using System.Reactive.Linq;");
+        builder.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(namespaceName))
+        {
+            builder.Append("namespace ").Append(namespaceName).AppendLine(";");
+            builder.AppendLine();
+        }
+
+        builder.Append("partial class ").Append(typeSymbol.Name).AppendLine();
+        builder.AppendLine("{");
+        builder.AppendLine("    private readonly global::System.Reactive.Disposables.CompositeDisposable _abPlcRxSubscriptions = new();");
+        builder.AppendLine("    private global::ABPlcRx.IABPlcRx? _abPlcRxController;");
+        builder.AppendLine();
+
+        foreach (var tag in tags)
+        {
+            AppendTagMembers(builder, tag);
+        }
+
+        AppendAttachMethod(builder, tags);
+        AppendDetachMethod(builder, tags);
+
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static void AppendTagMembers(StringBuilder builder, TagModel tag)
+    {
+        var fieldName = "_" + ToCamelCase(SanitizeIdentifier(tag.PropertyName));
+        var observableFieldName = fieldName + "Observable";
+
+        builder.Append("    private global::System.IObservable<").Append(tag.ObserveType).Append(">? ").Append(observableFieldName).AppendLine(";");
+
+        if (tag.GenerateProperty)
+        {
+            builder.Append("    private ").Append(tag.PropertyType).Append(' ').Append(fieldName).AppendLine(";");
+            builder.AppendLine();
+            builder.Append("    public ").Append(tag.PropertyType).Append(' ').Append(tag.PropertyName).AppendLine();
+            builder.AppendLine("    {");
+            builder.Append("        get => ").Append(fieldName).AppendLine(";");
+            builder.Append("        private set => ").Append(fieldName).AppendLine(" = value;");
+            builder.AppendLine("    }");
+        }
+
+        builder.AppendLine();
+        builder.Append("    public global::System.IObservable<").Append(tag.ObserveType).Append("> ").Append(tag.PropertyName).AppendLine("Observable =>");
+        builder.Append("        ").Append(observableFieldName).Append(" ?? throw new global::System.InvalidOperationException(\"Call ")
+            .Append("AttachPlcStreams").AppendLine(" before reading generated PLC observables.\");");
+        builder.AppendLine();
+        builder.AppendLine("#if NET8_0_OR_GREATER");
+        builder.Append("    public global::ReactiveUI.Extensions.Async.IObservableAsync<").Append(tag.ObserveType).Append("> ")
+            .Append(tag.PropertyName).AppendLine("ObservableAsync =>");
+        builder.Append("        global::ReactiveUI.Extensions.Async.ObservableBridgeExtensions.ToObservableAsync(")
+            .Append(tag.PropertyName).AppendLine("Observable);");
+        builder.AppendLine("#endif");
+        builder.AppendLine();
+    }
+
+    private static void AppendAttachMethod(StringBuilder builder, ImmutableArray<TagModel> tags)
+    {
+        builder.AppendLine("    public global::System.IDisposable AttachPlcStreams(global::ABPlcRx.IABPlcRx controller)");
+        builder.AppendLine("    {");
+        builder.AppendLine("        if (controller is null)");
+        builder.AppendLine("        {");
+        builder.AppendLine("            throw new global::System.ArgumentNullException(nameof(controller));");
+        builder.AppendLine("        }");
+        builder.AppendLine();
+        builder.AppendLine("        DetachPlcStreams();");
+        builder.AppendLine("        _abPlcRxController = controller;");
+        builder.AppendLine();
+
+        foreach (var tag in tags)
+        {
+            var observableFieldName = "_" + ToCamelCase(SanitizeIdentifier(tag.PropertyName)) + "Observable";
+            if (tag.RegisterTag)
+            {
+                builder.Append("        controller.AddUpdateTagItem<").Append(tag.RegisterType).Append(">(")
+                    .Append(ToLiteral(tag.Variable)).Append(", ")
+                    .Append(ToLiteral(tag.TagName)).Append(", ")
+                    .Append(ToLiteral(tag.Group)).AppendLine(");");
+            }
+
+            builder.Append("        ").Append(observableFieldName).Append(" = controller.Observe<").Append(tag.ObserveType).Append(">(")
+                .Append(ToLiteral(tag.Variable)).Append(", ").Append(tag.Bit.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .AppendLine(").Publish().RefCount();");
+            builder.Append("        _abPlcRxSubscriptions.Add(").Append(observableFieldName).Append(".Subscribe(value => ");
+            if (tag.RequiresValueGetOrDefault)
+            {
+                builder.Append(tag.PropertyName).AppendLine(" = value.GetValueOrDefault()));");
+            }
+            else
+            {
+                builder.Append(tag.PropertyName).AppendLine(" = value));");
+            }
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("        return global::System.Reactive.Disposables.Disposable.Create(DetachPlcStreams);");
+        builder.AppendLine("    }");
+        builder.AppendLine();
+    }
+
+    private static void AppendDetachMethod(StringBuilder builder, ImmutableArray<TagModel> tags)
+    {
+        builder.AppendLine("    public void DetachPlcStreams()");
+        builder.AppendLine("    {");
+        builder.AppendLine("        _abPlcRxSubscriptions.Clear();");
+        builder.AppendLine("        _abPlcRxController = null;");
+
+        foreach (var tag in tags)
+        {
+            builder.Append("        _").Append(ToCamelCase(SanitizeIdentifier(tag.PropertyName))).AppendLine("Observable = null;");
+        }
+
+        builder.AppendLine("    }");
+    }
+
+    private static bool HasAttribute(ImmutableArray<AttributeData> attributes, string metadataName) =>
+        attributes.Any(attribute => IsAttribute(attribute, metadataName));
+
+    private static bool IsAttribute(AttributeData attribute, string metadataName) =>
+        attribute.AttributeClass?.ToDisplayString() == metadataName;
+
+    private static bool IsPartial(TypeDeclarationSyntax declaration) =>
+        declaration.Modifiers.Any(SyntaxKind.PartialKeyword);
+
+    private static void ReportPartialRequired(GeneratorExecutionContext context, TypeDeclarationSyntax declaration, INamedTypeSymbol typeSymbol)
+    {
+        var descriptor = new DiagnosticDescriptor(
+            "ABPLCRXSG001",
+            "PLC stream model must be partial",
+            "Type '{0}' must be partial to generate ABPlcRx stream members",
+            "ABPlcRx.SourceGenerators",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        context.ReportDiagnostic(Diagnostic.Create(descriptor, declaration.Identifier.GetLocation(), typeSymbol.Name));
+    }
+
+    private static ITypeSymbol? GetNullableUnderlyingType(ITypeSymbol type) =>
+        type is INamedTypeSymbol namedType &&
+        namedType.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T
+            ? namedType.TypeArguments[0]
+            : null;
+
+    private static bool IsBoolean(ITypeSymbol type) =>
+        (GetNullableUnderlyingType(type) ?? type).SpecialType == SpecialType.System_Boolean;
+
+    private static string GetObserveType(ITypeSymbol type) =>
+        (GetNullableUnderlyingType(type) ?? type).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+    private static string GetSafeHintName(INamedTypeSymbol typeSymbol)
+    {
+        var name = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var builder = new StringBuilder(name.Length);
+        foreach (var character in name)
+        {
+            builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+        }
+
+        return builder.ToString();
+    }
+
+    private static string SanitizeIdentifier(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "Value";
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+        {
+            builder.Append(char.IsLetterOrDigit(character) || character == '_' ? character : '_');
+        }
+
+        if (builder.Length == 0 || !IsIdentifierStart(builder[0]))
+        {
+            builder.Insert(0, '_');
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsIdentifierStart(char value) =>
+        char.IsLetter(value) || value == '_';
+
+    private static string ToCamelCase(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "value";
+        }
+
+        return char.ToLowerInvariant(value[0]) + value.Substring(1);
+    }
+
+    private static string ToLiteral(string value) =>
+        "@\"" + value.Replace("\"", "\"\"") + "\"";
+
+    private readonly struct TagModel
+    {
+        public TagModel(
+            string propertyName,
+            string variable,
+            string tagName,
+            string group,
+            string observeType,
+            string propertyType,
+            string registerType,
+            int bit,
+            bool registerTag,
+            bool generateProperty,
+            bool requiresValueGetOrDefault)
+        {
+            PropertyName = SanitizeIdentifier(propertyName);
+            Variable = variable;
+            TagName = tagName;
+            Group = group;
+            ObserveType = observeType;
+            PropertyType = propertyType;
+            RegisterType = registerType;
+            Bit = bit;
+            RegisterTag = registerTag;
+            GenerateProperty = generateProperty;
+            RequiresValueGetOrDefault = requiresValueGetOrDefault;
+        }
+
+        public string PropertyName { get; }
+
+        public string Variable { get; }
+
+        public string TagName { get; }
+
+        public string Group { get; }
+
+        public string ObserveType { get; }
+
+        public string PropertyType { get; }
+
+        public string RegisterType { get; }
+
+        public int Bit { get; }
+
+        public bool RegisterTag { get; }
+
+        public bool GenerateProperty { get; }
+
+        public bool RequiresValueGetOrDefault { get; }
+    }
+
+    private readonly struct TagSettings
+    {
+        public TagSettings(string variable, string group, int bit, bool registerTag)
+        {
+            Variable = variable;
+            Group = group;
+            Bit = bit;
+            RegisterTag = registerTag;
+        }
+
+        public string Variable { get; }
+
+        public string Group { get; }
+
+        public int Bit { get; }
+
+        public bool RegisterTag { get; }
+    }
+
+    private sealed class Receiver : ISyntaxReceiver
+    {
+        public List<TypeDeclarationSyntax> Candidates { get; } = [];
+
+        public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+        {
+            if (syntaxNode is TypeDeclarationSyntax { AttributeLists.Count: > 0 } declaration)
+            {
+                Candidates.Add(declaration);
+            }
+        }
+    }
+}

--- a/src/ABPlcRx.Tests/ABPlcRx.Tests.csproj
+++ b/src/ABPlcRx.Tests/ABPlcRx.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);SA1600;CA1812</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="TUnit" Version="1.44.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ABPlcRx\ABPlcRx.csproj" />
+    <ProjectReference Include="..\ABPlcRx.SourceGenerators\ABPlcRx.SourceGenerators.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ABPlcRx.Tests/CoreBehaviorTests.cs
+++ b/src/ABPlcRx.Tests/CoreBehaviorTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using TUnit.Core;
+
+namespace ABPlcRx.Tests;
+
+public sealed class CoreBehaviorTests
+{
+    [Test]
+    public async Task CreateObjectNormalizesStringValues()
+    {
+        var value = TagHelper.CreateObject<NestedValue>(1);
+
+        Equal(string.Empty, value.Name);
+        Equal(string.Empty, value.Child.Text);
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task CreateObjectCreatesStringArraysWithEmptyEntries()
+    {
+        var values = TagHelper.CreateObject<string[]>(3);
+
+        Equal(3, values.Length);
+        True(values.All(static value => value == string.Empty), "Expected every generated string entry to be empty.");
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task BitsRoundTripKnownValues()
+    {
+        foreach (var value in new[] { 0, 1, 2, 255, -1 })
+        {
+            Equal(value, TagHelper.BitsToNumber(TagHelper.NumberToBits(value)));
+        }
+
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task ShortBitHelpersSetClearAndReadBits()
+    {
+        var value = ((short)0).SetBit(0, true);
+        Equal((short)1, value);
+        True(value.GetBit(0), "Bit 0 should be set.");
+
+        value = value.SetBit(0, false);
+        Equal((short)0, value);
+        False(value.GetBit(0), "Bit 0 should be cleared.");
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task PlcTagStatusClassifiesOnlyNonPendingNonOkCodesAsErrors()
+    {
+        False(PlcTagStatus.IsError(PlcTagStatus.StatusOK), "StatusOK should not be an error.");
+        False(PlcTagStatus.IsError(PlcTagStatus.StatusPending), "StatusPending should not be an error.");
+        True(PlcTagStatus.IsError(PlcTagStatus.ErrBadParam), "Negative libplctag status codes should be errors.");
+        await Task.CompletedTask;
+    }
+
+    private static void Equal<T>(T expected, T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
+        }
+    }
+
+    private static void True(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private static void False(bool condition, string message) => True(!condition, message);
+
+    private sealed class NestedValue
+    {
+        public string? Name { get; set; }
+
+        public NestedChild Child { get; set; } = new();
+    }
+
+    private sealed class NestedChild
+    {
+        public string? Text { get; set; }
+    }
+}

--- a/src/ABPlcRx.Tests/ReactiveSurfaceTests.cs
+++ b/src/ABPlcRx.Tests/ReactiveSurfaceTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ReactiveUI.Extensions.Async;
+using TUnit.Core;
+
+namespace ABPlcRx.Tests;
+
+public sealed class ReactiveSurfaceTests
+{
+    [Test]
+    public async Task ObserveManyWithNoVariablesEmitsEmptyDictionary()
+    {
+        using var plc = new global::ABPlcRx.ABPlcRx(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+        var completion = new TaskCompletionSource<IReadOnlyDictionary<string, object?>>();
+
+        using var subscription = plc.ObserveMany().Subscribe(completion.SetResult);
+        var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Equal(0, result.Count);
+    }
+
+    [Test]
+    public async Task AddUpdateTagItemValidationRunsBeforeNativeTagCreation()
+    {
+        using var plc = new global::ABPlcRx.ABPlcRx(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+
+        Throws<ArgumentNullException>(() => plc.AddUpdateTagItem<int>(string.Empty, "N7:0", "Default"));
+        Throws<ArgumentNullException>(() => plc.AddUpdateTagItem<int>("Counter", string.Empty, "Default"));
+        Throws<ArgumentNullException>(() => plc.AddUpdateTagItem<int>("Counter", "N7:0", string.Empty));
+        Throws<Exception>(() => plc.AddUpdateTagItem<bool>("Flag", "B3:0", "Default"));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task AsyncObservableSurfaceWrapsExistingObservablePipelines()
+    {
+        using var plc = new global::ABPlcRx.ABPlcRx(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+
+        IsAssignableTo<IObservableAsync<IPlcTag?>>(plc.ObserveAllAsync);
+        IsAssignableTo<IObservableAsync<IReadOnlyDictionary<string, object?>>>(plc.ObserveManyAsync());
+        IsAssignableTo<IObservableAsync<PlcTagResult>>(plc.ObserveErrorsAsync());
+        await Task.CompletedTask;
+    }
+
+    private static void Equal<T>(T expected, T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
+        }
+    }
+
+    private static void Throws<TException>(Action action)
+        where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"Expected exception of type {typeof(TException).Name}.");
+    }
+
+    private static void IsAssignableTo<T>(object value)
+    {
+        if (value is not T)
+        {
+            throw new InvalidOperationException($"Expected value assignable to {typeof(T).FullName}.");
+        }
+    }
+}

--- a/src/ABPlcRx.Tests/SourceGeneratorTests.cs
+++ b/src/ABPlcRx.Tests/SourceGeneratorTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ABPlcRx.SourceGeneration;
+using ABPlcRx.SourceGenerators;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ReactiveUI.Extensions.Async;
+using TUnit.Core;
+
+namespace ABPlcRx.Tests;
+
+public sealed class SourceGeneratorTests
+{
+    [Test]
+    public async Task PlcModelGeneratorCreatesPropertiesAndObservableStreams()
+    {
+        const string source = """
+            using ABPlcRx.SourceGeneration;
+
+            namespace GeneratedSample;
+
+            [PlcModel]
+            [PlcTag(typeof(int), "Counter", "MyDINT")]
+            [PlcTag(typeof(bool), "LightOn", "B3:3", Bit = 0)]
+            public partial class MachineTags
+            {
+            }
+            """;
+
+        var compilation = CreateCompilation(source);
+        var generator = new PlcModelGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [generator],
+            parseOptions: new CSharpParseOptions(LanguageVersion.Preview));
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        NoErrors(diagnostics);
+        NoErrors(outputCompilation.GetDiagnostics());
+
+        var generatedSource = driver
+            .GetRunResult()
+            .GeneratedTrees
+            .Single(tree => tree.FilePath.EndsWith(".ABPlcRx.g.cs", StringComparison.Ordinal))
+            .GetText()
+            .ToString();
+
+        Contains("CounterObservable", generatedSource);
+        Contains("LightOnObservable", generatedSource);
+        Contains("LightOnObservableAsync", generatedSource);
+        Contains("controller.AddUpdateTagItem<short>(@\"LightOn\", @\"B3:3\", @\"Default\")", generatedSource);
+
+        await Task.CompletedTask;
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var references = GetFrameworkReferences()
+            .Concat(new[]
+            {
+                MetadataReference.CreateFromFile(typeof(PlcModelAttribute).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(IABPlcRx).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Reactive.Linq.Observable).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(IObservableAsync<>).Assembly.Location),
+            });
+
+        return CSharpCompilation.Create(
+            "GeneratedSample",
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static IEnumerable<MetadataReference> GetFrameworkReferences()
+    {
+        var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+        if (string.IsNullOrWhiteSpace(trustedPlatformAssemblies))
+        {
+            return [];
+        }
+
+        return trustedPlatformAssemblies
+            .Split(Path.PathSeparator)
+            .Where(File.Exists)
+            .Select(path => MetadataReference.CreateFromFile(path));
+    }
+
+    private static void NoErrors(IEnumerable<Diagnostic> diagnostics)
+    {
+        var errors = diagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        if (errors.Length != 0)
+        {
+            throw new InvalidOperationException(string.Join(Environment.NewLine, errors.Select(static error => error.ToString())));
+        }
+    }
+
+    private static void Contains(string expected, string actual)
+    {
+        if (!actual.Contains(expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected generated source to contain '{expected}'.");
+        }
+    }
+}

--- a/src/ABPlcRx.sln
+++ b/src/ABPlcRx.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11012.119 d18.0
+VisualStudioVersion = 18.0.11012.119
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ABPlcRx", "ABPlcRx\ABPlcRx.csproj", "{FBF73FFD-5215-46C3-A37F-A6C3208895AF}"
 EndProject
@@ -21,22 +21,78 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionConfig", "SolutionC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{FCD1C061-4486-4964-A090-0C645881D24B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ABPlcRx.SourceGenerators", "ABPlcRx.SourceGenerators\ABPlcRx.SourceGenerators.csproj", "{65583846-57D3-4D36-86C4-38167AA6DE0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ABPlcRx.Tests", "ABPlcRx.Tests\ABPlcRx.Tests.csproj", "{101E6D64-3C81-4ED1-9421-53508983C31F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Debug|x86.Build.0 = Debug|Any CPU
 		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Release|x64.Build.0 = Release|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{FBF73FFD-5215-46C3-A37F-A6C3208895AF}.Release|x86.Build.0 = Release|Any CPU
 		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Debug|x64.Build.0 = Debug|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Debug|x86.Build.0 = Debug|Any CPU
 		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Release|x64.ActiveCfg = Release|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Release|x64.Build.0 = Release|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Release|x86.ActiveCfg = Release|Any CPU
+		{02E930D1-D3DB-4FC2-9807-71BAC232263C}.Release|x86.Build.0 = Release|Any CPU
 		{FCD1C061-4486-4964-A090-0C645881D24B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Debug|x86.Build.0 = Debug|Any CPU
 		{FCD1C061-4486-4964-A090-0C645881D24B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Release|x64.Build.0 = Release|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Release|x86.ActiveCfg = Release|Any CPU
+		{FCD1C061-4486-4964-A090-0C645881D24B}.Release|x86.Build.0 = Release|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Debug|x64.Build.0 = Debug|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Debug|x86.Build.0 = Debug|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Release|x64.ActiveCfg = Release|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Release|x64.Build.0 = Release|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Release|x86.ActiveCfg = Release|Any CPU
+		{65583846-57D3-4D36-86C4-38167AA6DE0B}.Release|x86.Build.0 = Release|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Debug|x64.Build.0 = Debug|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Debug|x86.Build.0 = Debug|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Release|x64.ActiveCfg = Release|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Release|x64.Build.0 = Release|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Release|x86.ActiveCfg = Release|Any CPU
+		{101E6D64-3C81-4ED1-9421-53508983C31F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ABPlcRx/ABPlcRx.cs
+++ b/src/ABPlcRx/ABPlcRx.cs
@@ -5,6 +5,9 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+#if NET8_0_OR_GREATER
+using ReactiveUI.Extensions.Async;
+#endif
 
 namespace ABPlcRx;
 
@@ -76,6 +79,14 @@ public class ABPlcRx : IABPlcRx
     /// </summary>
     /// <value>The data read.</value>
     public IObservable<IPlcTag?> ObserveAll => _plc.Tags.Select(x => x.Changed).Merge().Select(c => c.Tag);
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Gets the data read as an async-native observable.
+    /// </summary>
+    /// <value>The async data read stream.</value>
+    public IObservableAsync<IPlcTag?> ObserveAllAsync => ObserveAll.ToObservableAsync();
+#endif
 
     /// <summary>
     /// Gets or sets a value indicating whether [scan enabled].
@@ -180,6 +191,20 @@ public class ABPlcRx : IABPlcRx
             .Publish()
             .RefCount();
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observes the specified variable as an async-native observable.
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    /// <param name="variable">The variable.</param>
+    /// <param name="bit">The bit.</param>
+    /// <returns>
+    /// An async observable of T.
+    /// </returns>
+    public IObservableAsync<T?> ObserveAsync<T>(string? variable, int bit = -1) =>
+        Observe<T>(variable, bit).ToObservableAsync();
+#endif
+
     /// <summary>
     /// Observe values for many variables and emit a latest-value dictionary.
     /// </summary>
@@ -213,6 +238,16 @@ public class ABPlcRx : IABPlcRx
             .RefCount();
     }
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe values for many variables and emit a latest-value dictionary as an async-native observable.
+    /// </summary>
+    /// <param name="variables">One or more variable names to observe.</param>
+    /// <returns>Async observable sequence of dictionary containing the latest values for each variable.</returns>
+    public IObservableAsync<IReadOnlyDictionary<string, object?>> ObserveManyAsync(params string[] variables) =>
+        ObserveMany(variables).ToObservableAsync();
+#endif
+
     /// <summary>
     /// Observe a PLC tag group, emitting the tag whose value changed.
     /// </summary>
@@ -235,6 +270,16 @@ public class ABPlcRx : IABPlcRx
         })
         .Publish()
         .RefCount();
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe a PLC tag group as an async-native observable.
+    /// </summary>
+    /// <param name="groupName">The group name to observe.</param>
+    /// <returns>Async observable sequence of tags in the group that have changed.</returns>
+    public IObservableAsync<IPlcTag> ObserveGroupAsync(string groupName) =>
+        ObserveGroup(groupName).ToObservableAsync();
+#endif
 
     /// <summary>
     /// Creates an observer that writes values to a PLC variable when OnNext is called.
@@ -262,12 +307,35 @@ public class ABPlcRx : IABPlcRx
     public IObservable<T?> ObserveSampled<T>(string variable, TimeSpan sampleInterval, int bit = -1, IScheduler? scheduler = null)
         => Observe<T>(variable, bit).Sample(sampleInterval, scheduler ?? TaskPoolScheduler.Default).DistinctUntilChanged().Publish().RefCount();
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe a variable with sampling as an async-native observable.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="variable">The variable to observe.</param>
+    /// <param name="sampleInterval">The sampling interval.</param>
+    /// <param name="bit">The bit [ONLY use for bool tags].</param>
+    /// <param name="scheduler">Optional scheduler for sampling.</param>
+    /// <returns>Async observable sequence of sampled values.</returns>
+    public IObservableAsync<T?> ObserveSampledAsync<T>(string variable, TimeSpan sampleInterval, int bit = -1, IScheduler? scheduler = null)
+        => ObserveSampled<T>(variable, sampleInterval, bit, scheduler).ToObservableAsync();
+#endif
+
     /// <summary>
     /// Streams only error results across all tags.
     /// </summary>
     /// <returns>Observable sequence of error results.</returns>
     public IObservable<PlcTagResult> ObserveErrors()
         => _plc.Tags.Select(x => x.Changed).Merge().Where(r => PlcTagStatus.IsError(r.StatusCode)).Publish().RefCount();
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Streams only error results across all tags as an async-native observable.
+    /// </summary>
+    /// <returns>Async observable sequence of error results.</returns>
+    public IObservableAsync<PlcTagResult> ObserveErrorsAsync() =>
+        ObserveErrors().ToObservableAsync();
+#endif
 
     /// <summary>
     /// Ping the PLC.
@@ -297,6 +365,18 @@ public class ABPlcRx : IABPlcRx
                       .DistinctUntilChanged()
                       .Publish()
                       .RefCount();
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe ping results on a schedule as an async-native observable.
+    /// </summary>
+    /// <param name="interval">The interval between pings.</param>
+    /// <param name="echo">True echo result to standard output.</param>
+    /// <param name="scheduler">Optional scheduler for the ping cadence.</param>
+    /// <returns>Async observable sequence of ping result states, deduplicated.</returns>
+    public IObservableAsync<bool> ObservePingAsync(TimeSpan interval, bool echo = false, IScheduler? scheduler = null) =>
+        ObservePing(interval, echo, scheduler).ToObservableAsync();
+#endif
 
     /// <summary>
     /// Reads the specified variable.

--- a/src/ABPlcRx/ABPlcRx.csproj
+++ b/src/ABPlcRx/ABPlcRx.csproj
@@ -17,5 +17,9 @@
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard2'))">
+    <PackageReference Include="ReactiveUI.Extensions" Version="2.3.1" />
+  </ItemGroup>
   
 </Project>

--- a/src/ABPlcRx/IABPlcRx.cs
+++ b/src/ABPlcRx/IABPlcRx.cs
@@ -6,6 +6,9 @@ using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Threading;
 using System.Threading.Tasks;
+#if NET8_0_OR_GREATER
+using ReactiveUI.Extensions.Async;
+#endif
 
 namespace ABPlcRx;
 
@@ -22,6 +25,16 @@ public interface IABPlcRx : ICancelable
     /// The observe all.
     /// </value>
     IObservable<IPlcTag?> ObserveAll { get; }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Gets the asynchronous observe all stream.
+    /// </summary>
+    /// <value>
+    /// The asynchronous observe all stream.
+    /// </value>
+    IObservableAsync<IPlcTag?> ObserveAllAsync { get; }
+#endif
 
     /// <summary>
     /// Gets or sets a value indicating whether [scan enabled].
@@ -80,6 +93,19 @@ public interface IABPlcRx : ICancelable
     /// </returns>
     IObservable<T?> Observe<T>(string? variable, int bit = -1);
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observes the specified variable using an async-native observable.
+    /// </summary>
+    /// <typeparam name="T">The PLC type.</typeparam>
+    /// <param name="variable">The variable.</param>
+    /// <param name="bit">The bit.</param>
+    /// <returns>
+    /// An async observable sequence of values of type T.
+    /// </returns>
+    IObservableAsync<T?> ObserveAsync<T>(string? variable, int bit = -1);
+#endif
+
     /// <summary>
     /// Observe values for many variables and emit a latest-value dictionary.
     /// </summary>
@@ -87,12 +113,30 @@ public interface IABPlcRx : ICancelable
     /// <returns>Observable sequence of dictionary containing the latest values for each variable.</returns>
     IObservable<IReadOnlyDictionary<string, object?>> ObserveMany(params string[] variables);
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe values for many variables using an async-native observable.
+    /// </summary>
+    /// <param name="variables">One or more variable names to observe.</param>
+    /// <returns>Async observable sequence of dictionary containing the latest values for each variable.</returns>
+    IObservableAsync<IReadOnlyDictionary<string, object?>> ObserveManyAsync(params string[] variables);
+#endif
+
     /// <summary>
     /// Observe a PLC tag group, emitting the tag whose value changed.
     /// </summary>
     /// <param name="groupName">The group name to observe.</param>
     /// <returns>Observable sequence of tags in the group that have changed.</returns>
     IObservable<IPlcTag> ObserveGroup(string groupName);
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe a PLC tag group using an async-native observable.
+    /// </summary>
+    /// <param name="groupName">The group name to observe.</param>
+    /// <returns>Async observable sequence of tags in the group that have changed.</returns>
+    IObservableAsync<IPlcTag> ObserveGroupAsync(string groupName);
+#endif
 
     /// <summary>
     /// Creates an observer that writes values to a PLC variable when OnNext is called.
@@ -114,11 +158,32 @@ public interface IABPlcRx : ICancelable
     /// <returns>Observable sequence of sampled values.</returns>
     IObservable<T?> ObserveSampled<T>(string variable, TimeSpan sampleInterval, int bit = -1, IScheduler? scheduler = null);
 
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe a variable with sampling using an async-native observable.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="variable">The variable to observe.</param>
+    /// <param name="sampleInterval">The sampling interval.</param>
+    /// <param name="bit">The bit [ONLY use for bool tags].</param>
+    /// <param name="scheduler">Optional scheduler for sampling.</param>
+    /// <returns>Async observable sequence of sampled values.</returns>
+    IObservableAsync<T?> ObserveSampledAsync<T>(string variable, TimeSpan sampleInterval, int bit = -1, IScheduler? scheduler = null);
+#endif
+
     /// <summary>
     /// Streams only error results across all tags.
     /// </summary>
     /// <returns>Observable sequence of error results.</returns>
     IObservable<PlcTagResult> ObserveErrors();
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Streams only error results across all tags using an async-native observable.
+    /// </summary>
+    /// <returns>Async observable sequence of error results.</returns>
+    IObservableAsync<PlcTagResult> ObserveErrorsAsync();
+#endif
 
     /// <summary>
     /// Values the specified variable.
@@ -189,4 +254,15 @@ public interface IABPlcRx : ICancelable
     /// <param name="scheduler">Optional scheduler for the ping cadence.</param>
     /// <returns>Observable sequence of ping result states, deduplicated.</returns>
     IObservable<bool> ObservePing(TimeSpan interval, bool echo = false, IScheduler? scheduler = null);
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Observe ping results on a schedule using an async-native observable.
+    /// </summary>
+    /// <param name="interval">The interval between pings.</param>
+    /// <param name="echo">True echo result to standard output.</param>
+    /// <param name="scheduler">Optional scheduler for the ping cadence.</param>
+    /// <returns>Async observable sequence of ping result states, deduplicated.</returns>
+    IObservableAsync<bool> ObservePingAsync(TimeSpan interval, bool echo = false, IScheduler? scheduler = null);
+#endif
 }

--- a/src/ABPlcRx/SourceGeneration/PlcModelAttribute.cs
+++ b/src/ABPlcRx/SourceGeneration/PlcModelAttribute.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ABPlcRx.SourceGeneration;
+
+/// <summary>
+/// Marks a partial type as a PLC reactive stream model.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class PlcModelAttribute : Attribute
+{
+}

--- a/src/ABPlcRx/SourceGeneration/PlcTagAttribute.cs
+++ b/src/ABPlcRx/SourceGeneration/PlcTagAttribute.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ABPlcRx.SourceGeneration;
+
+/// <summary>
+/// Describes a PLC tag stream that should be generated for a partial model.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+public sealed class PlcTagAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlcTagAttribute"/> class for a property-declared tag.
+    /// </summary>
+    /// <param name="tagName">The PLC tag name.</param>
+    public PlcTagAttribute(string tagName) => TagName = tagName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlcTagAttribute"/> class for a generated property.
+    /// </summary>
+    /// <param name="valueType">The PLC value type.</param>
+    /// <param name="propertyName">The generated property name.</param>
+    /// <param name="tagName">The PLC tag name.</param>
+    public PlcTagAttribute(Type valueType, string propertyName, string tagName)
+    {
+        ValueType = valueType;
+        PropertyName = propertyName;
+        TagName = tagName;
+    }
+
+    /// <summary>
+    /// Gets the PLC tag name.
+    /// </summary>
+    public string TagName { get; }
+
+    /// <summary>
+    /// Gets the generated property value type when the attribute is applied to a class.
+    /// </summary>
+    public Type? ValueType { get; }
+
+    /// <summary>
+    /// Gets the generated property name when the attribute is applied to a class.
+    /// </summary>
+    public string? PropertyName { get; }
+
+    /// <summary>
+    /// Gets or sets the application variable key. Defaults to the property name.
+    /// </summary>
+    public string? Variable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tag group.
+    /// </summary>
+    public string Group { get; set; } = "Default";
+
+    /// <summary>
+    /// Gets or sets the bit index for boolean bit access.
+    /// </summary>
+    public int Bit { get; set; } = -1;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether generated attach logic should register the tag.
+    /// </summary>
+    public bool RegisterTag { get; set; } = true;
+}


### PR DESCRIPTION
Introduce a source generator project and async-native observable surface plus tests and docs.

- Add ABPlcRx.SourceGenerators project with PlcModelGenerator (Roslyn source generator) and attributes to generate typed PLC stream models and observables.
- Add ABPlcRx.Tests project with unit tests for core behavior, reactive surface, and the source generator.
- Extend ABPlcRx and IABPlcRx to expose IObservableAsync-based APIs (ObserveAllAsync, ObserveAsync, ObserveManyAsync, ObserveGroupAsync, ObserveSampledAsync, ObserveErrorsAsync, ObservePingAsync) guarded by NET8_0_OR_GREATER and wire up ReactiveUI.Extensions when available.
- Update ABPlcRx.csproj to conditionally reference ReactiveUI.Extensions for non-netstandard targets.
- Update README with documentation and examples for async observables and the source generator, and add test/run instructions.
- Add global.json test runner setting and update solution to include the new projects and build configurations.

These changes add compile-time model generation for PLC streams and an async-native observable surface for .NET 8+ while including tests and documentation to validate and demonstrate the features.