### PR TITLE
Package ABPlcRx source generator and support direct Logix BOOL tags

### DIFF
--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -53,5 +53,10 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Clean build artifacts'
+        run: |
+          Remove-Item -Recurse -Force ".\src\*\bin" -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force ".\src\*\obj" -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force ".\build\obj" -ErrorAction SilentlyContinue
       - name: 'Run: Compile'
         run: ./build.cmd Compile

--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -53,10 +53,13 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Clean build artifacts'
+      - name: 'Clean build artifacts and kill compiler processes'
         run: |
           Remove-Item -Recurse -Force ".\src\*\bin" -ErrorAction SilentlyContinue
           Remove-Item -Recurse -Force ".\src\*\obj" -ErrorAction SilentlyContinue
           Remove-Item -Recurse -Force ".\build\obj" -ErrorAction SilentlyContinue
+          Stop-Process -Name "VBCSCompiler" -Force -ErrorAction SilentlyContinue
+          Stop-Process -Name "dotnet" -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 2
       - name: 'Run: Compile'
         run: ./build.cmd Compile

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ Installation
 - Install the NuGet package:
   - Package Manager: Install-Package ABPlcRx
   - .NET CLI: dotnet add package ABPlcRx
-- To generate typed stream models, add the source generator package/project as an analyzer:
-  - Package Manager: Install-Package ABPlcRx.SourceGenerators
-  - .NET CLI: dotnet add package ABPlcRx.SourceGenerators
+- The ABPlcRx package includes its source generator analyzer; no separate generator package is required for normal NuGet consumption.
 - ABPlcRx depends on libplctag; the NuGet dependency brings required bindings.
 
 Basic concepts
@@ -86,10 +84,17 @@ var lgx = new ABPlcRx(PlcType.LGX, "192.168.1.60", TimeSpan.FromMilliseconds(200
 lgx.AddUpdateTagItem<int>("Counter", "MyDINT", "Default");
 
 // Observe numeric values
-glx.Observe<int>("Counter").Subscribe(v => Console.WriteLine($"Counter={v}"));
+lgx.Observe<int>("Counter").Subscribe(v => Console.WriteLine($"Counter={v}"));
 
 // Increment and write
-glx.Value("Counter", lgx.Value<int>("Counter") + 1);
+lgx.Value("Counter", lgx.Value<int>("Counter") + 1);
+
+// Standard Logix BOOL tag named MachineReady
+lgx.AddUpdateTagItem<bool>("Ready", "MachineReady", "Default");
+lgx.Observe<bool>("Ready").Subscribe(v => Console.WriteLine($"Ready={v}"));
+
+var ready = !lgx.Value<bool>("Ready");
+lgx.Value("Ready", ready);
 ```
 
 Reactive API highlights
@@ -141,7 +146,7 @@ tags.LightOnObservable.Subscribe(value => Console.WriteLine($"LightOn={value}"))
 var asyncLightOn = tags.LightOnObservableAsync;
 ```
 
-The generator creates a property for each class-level `PlcTag` attribute, registers tags in `AttachPlcStreams`, keeps the generated property updated from the observable subscription, and exposes both `PropertyNameObservable` and `PropertyNameObservableAsync` on .NET 8+. Boolean bit tags are registered as `short` tags and exposed as `bool` values.
+The generator creates a property for each class-level `PlcTag` attribute, registers tags in `AttachPlcStreams`, keeps the generated property updated from the observable subscription, and exposes both `PropertyNameObservable` and `PropertyNameObservableAsync` on .NET 8+. Boolean tags without a `Bit` value are registered as native `bool` tags. Boolean bit tags with `Bit` set are registered as `short` tags and exposed as `bool` values.
 
 Examples
 Observe multiple variables
@@ -212,7 +217,8 @@ dotnet test src/ABPlcRx.sln
 ```
 
 Data types and bit access
-- To treat a single bit as a boolean, create the tag as `short` and use the `bit` parameter (0‑15).
+- Logix/CompactLogix/Micro800 standard `BOOL` tags can be created directly with `AddUpdateTagItem<bool>("Ready", "MachineReady")` and read or written with `Value<bool>("Ready")`.
+- To treat a single bit in an SLC/PLC word as a boolean, create the tag as `short` and use the `bit` parameter (0‑15).
 - For numeric tags use C# primitive types: sbyte/byte/short/ushort/int/uint/long/ulong/float/double.
 - Strings and structure types are supported where the PLC and libplctag support them.
 

--- a/src/ABPlcRx.SourceGenerators/ABPlcRx.SourceGenerators.csproj
+++ b/src/ABPlcRx.SourceGenerators/ABPlcRx.SourceGenerators.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>12</LangVersion>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

--- a/src/ABPlcRx.SourceGenerators/PlcModelGenerator.cs
+++ b/src/ABPlcRx.SourceGenerators/PlcModelGenerator.cs
@@ -110,7 +110,7 @@ public sealed class PlcModelGenerator : ISourceGenerator
             settings.Group,
             GetObserveType(valueType),
             GetObserveType(valueType),
-            IsBoolean(valueType) ? "short" : GetObserveType(valueType),
+            GetRegisterType(valueType, settings.Bit),
             settings.Bit,
             settings.RegisterTag,
             generateProperty: true,
@@ -137,7 +137,7 @@ public sealed class PlcModelGenerator : ISourceGenerator
             settings.Group,
             GetObserveType(valueType),
             property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-            IsBoolean(valueType) ? "short" : GetObserveType(valueType),
+            GetRegisterType(valueType, settings.Bit),
             settings.Bit,
             settings.RegisterTag,
             generateProperty: false,
@@ -330,6 +330,9 @@ public sealed class PlcModelGenerator : ISourceGenerator
 
     private static bool IsBoolean(ITypeSymbol type) =>
         (GetNullableUnderlyingType(type) ?? type).SpecialType == SpecialType.System_Boolean;
+
+    private static string GetRegisterType(ITypeSymbol type, int bit) =>
+        IsBoolean(type) && bit >= 0 ? "short" : GetObserveType(type);
 
     private static string GetObserveType(ITypeSymbol type) =>
         (GetNullableUnderlyingType(type) ?? type).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);

--- a/src/ABPlcRx.Tests/CoreBehaviorTests.cs
+++ b/src/ABPlcRx.Tests/CoreBehaviorTests.cs
@@ -28,6 +28,15 @@ public sealed class CoreBehaviorTests
     }
 
     [Test]
+    public async Task CreateObjectCreatesBoolDefault()
+    {
+        var value = TagHelper.CreateObject<bool>(1);
+
+        False(value, "The generated default BOOL value should be false.");
+        await Task.CompletedTask;
+    }
+
+    [Test]
     public async Task BitsRoundTripKnownValues()
     {
         foreach (var value in new[] { 0, 1, 2, 255, -1 })

--- a/src/ABPlcRx.Tests/ReactiveSurfaceTests.cs
+++ b/src/ABPlcRx.Tests/ReactiveSurfaceTests.cs
@@ -28,7 +28,7 @@ public sealed class ReactiveSurfaceTests
         Throws<ArgumentNullException>(() => plc.AddUpdateTagItem<int>(string.Empty, "N7:0", "Default"));
         Throws<ArgumentNullException>(() => plc.AddUpdateTagItem<int>("Counter", string.Empty, "Default"));
         Throws<ArgumentNullException>(() => plc.AddUpdateTagItem<int>("Counter", "N7:0", string.Empty));
-        Throws<Exception>(() => plc.AddUpdateTagItem<bool>("Flag", "B3:0", "Default"));
+        DoesNotThrow(() => plc.AddUpdateTagItem<bool>("Flag", "BoolTest", "Default"));
         await Task.CompletedTask;
     }
 
@@ -38,8 +38,13 @@ public sealed class ReactiveSurfaceTests
         using var plc = new global::ABPlcRx.ABPlcRx(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
 
         IsAssignableTo<IObservableAsync<IPlcTag?>>(plc.ObserveAllAsync);
+        IsAssignableTo<IObservableAsync<int>>(plc.ObserveAsync<int>("Counter"));
         IsAssignableTo<IObservableAsync<IReadOnlyDictionary<string, object?>>>(plc.ObserveManyAsync());
+        IsAssignableTo<IObservableAsync<IPlcTag>>(plc.ObserveGroupAsync("Default"));
+        IsAssignableTo<IObservableAsync<int>>(plc.ObserveSampledAsync<int>("Counter", TimeSpan.FromMilliseconds(100)));
         IsAssignableTo<IObservableAsync<PlcTagResult>>(plc.ObserveErrorsAsync());
+        IsAssignableTo<IObservableAsync<bool>>(plc.ObservePingAsync(TimeSpan.FromSeconds(1)));
+        IsAssignableTo<IObservable<int>>(ObservableBridgeExtensions.ToObservable(plc.ObserveAsync<int>("Counter")));
         await Task.CompletedTask;
     }
 
@@ -64,6 +69,18 @@ public sealed class ReactiveSurfaceTests
         }
 
         throw new InvalidOperationException($"Expected exception of type {typeof(TException).Name}.");
+    }
+
+    private static void DoesNotThrow(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Expected no exception.", ex);
+        }
     }
 
     private static void IsAssignableTo<T>(object value)

--- a/src/ABPlcRx.Tests/SourceGeneratorTests.cs
+++ b/src/ABPlcRx.Tests/SourceGeneratorTests.cs
@@ -23,6 +23,7 @@ public sealed class SourceGeneratorTests
             [PlcModel]
             [PlcTag(typeof(int), "Counter", "MyDINT")]
             [PlcTag(typeof(bool), "LightOn", "B3:3", Bit = 0)]
+            [PlcTag(typeof(bool), "Ready", "MachineReady")]
             public partial class MachineTags
             {
             }
@@ -48,7 +49,11 @@ public sealed class SourceGeneratorTests
         Contains("CounterObservable", generatedSource);
         Contains("LightOnObservable", generatedSource);
         Contains("LightOnObservableAsync", generatedSource);
+        Contains("ReadyObservable", generatedSource);
+        Contains("ReadyObservableAsync", generatedSource);
         Contains("controller.AddUpdateTagItem<short>(@\"LightOn\", @\"B3:3\", @\"Default\")", generatedSource);
+        Contains("controller.AddUpdateTagItem<bool>(@\"Ready\", @\"MachineReady\", @\"Default\")", generatedSource);
+        Contains("controller.Observe<bool>(@\"Ready\", -1)", generatedSource);
 
         await Task.CompletedTask;
     }

--- a/src/ABPlcRx/ABPlcRx.cs
+++ b/src/ABPlcRx/ABPlcRx.cs
@@ -506,7 +506,9 @@ public class ABPlcRx : IABPlcRx
 
         if (bit < 0 || bit >= bitWidth)
         {
-            throw new ArgumentOutOfRangeException(nameof(bit), $"Bit must be between 0 and {bitWidth - 1} for {tagType.Name} tags.");
+            throw new ArgumentOutOfRangeException(
+                nameof(bit),
+                $"Bit must be between 0 and {bitWidth - 1} for {tagType.Name} tags.");
         }
     }
 

--- a/src/ABPlcRx/ABPlcRx.cs
+++ b/src/ABPlcRx/ABPlcRx.cs
@@ -132,7 +132,6 @@ public class ABPlcRx : IABPlcRx
     /// <param name="tagName">Name of the tag.</param>
     /// <param name="tagGroup">The tag group.</param>
     /// <exception cref="System.ArgumentNullException">tagName.</exception>
-    /// <exception cref="System.Exception">Please use type of short, then use bool for other operations and set the bit number.</exception>
     public void AddUpdateTagItem<T>(string variable, string tagName, string tagGroup)
     {
         if (string.IsNullOrWhiteSpace(variable))
@@ -148,11 +147,6 @@ public class ABPlcRx : IABPlcRx
         if (string.IsNullOrWhiteSpace(tagGroup))
         {
             throw new ArgumentNullException(nameof(tagGroup));
-        }
-
-        if (typeof(T).Equals(typeof(bool)))
-        {
-            throw new Exception("Please use type of short, then use bool for other operations and set the bit number.");
         }
 
         _plc.AddTagToGroup<T>(variable, tagName!, _scanInterval, tagGroup);
@@ -425,13 +419,9 @@ public class ABPlcRx : IABPlcRx
 
         if (typeof(T).Equals(typeof(bool)))
         {
-            if (bit == -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bit), "You must set the bit value for bool types.");
-            }
-
-            object objValue = value!;
-            tag!.Value = ((short)tag!.Value!).SetBit(bit, (bool)objValue!);
+            tag.Value = tag.TypeValue == typeof(bool)
+                ? value
+                : SetTagBitValue(tag, bit, value);
         }
         else
         {
@@ -473,20 +463,84 @@ public class ABPlcRx : IABPlcRx
     {
         if (typeof(T).Equals(typeof(bool)))
         {
-            if (bit == -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bit), "You must set the bit value for bool types.");
-            }
-
             if (tag == null)
             {
                 return default;
             }
 
-            object? boolVal = ((short)tag?.Value!).GetBit(bit);
+            var boolVal = tag.TypeValue == typeof(bool)
+                ? tag.Value
+                : GetTagBitValue(tag, bit);
+
             return (T?)boolVal;
         }
 
         return (T?)tag?.Value;
     }
+
+    private static bool GetTagBitValue(IPlcTag tag, int bit)
+    {
+        ValidateBitIndex(tag.TypeValue, bit);
+        return (GetUnsignedIntegralValue(tag.Value, tag.TypeValue) & (1UL << bit)) != 0;
+    }
+
+    private static object SetTagBitValue<T>(IPlcTag tag, int bit, T? value)
+    {
+        ValidateBitIndex(tag.TypeValue, bit);
+        var rawValue = GetUnsignedIntegralValue(tag.Value, tag.TypeValue);
+        var mask = 1UL << bit;
+        var updated = value is true ? rawValue | mask : rawValue & ~mask;
+        return ConvertUnsignedIntegralValue(updated, tag.TypeValue);
+    }
+
+    private static void ValidateBitIndex(Type tagType, int bit)
+    {
+        var bitWidth = Type.GetTypeCode(tagType) switch
+        {
+            TypeCode.Byte or TypeCode.SByte => 8,
+            TypeCode.UInt16 or TypeCode.Int16 => 16,
+            TypeCode.UInt32 or TypeCode.Int32 => 32,
+            TypeCode.UInt64 or TypeCode.Int64 => 64,
+            _ => throw new ArgumentException("Bit operations require an integral PLC tag type.", nameof(tagType)),
+        };
+
+        if (bit < 0 || bit >= bitWidth)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bit), $"Bit must be between 0 and {bitWidth - 1} for {tagType.Name} tags.");
+        }
+    }
+
+    private static ulong GetUnsignedIntegralValue(object? value, Type tagType)
+    {
+        if (value is null)
+        {
+            return 0;
+        }
+
+        return Type.GetTypeCode(tagType) switch
+        {
+            TypeCode.Byte => (byte)value,
+            TypeCode.SByte => unchecked((ulong)(sbyte)value),
+            TypeCode.UInt16 => (ushort)value,
+            TypeCode.Int16 => unchecked((ulong)(short)value),
+            TypeCode.UInt32 => (uint)value,
+            TypeCode.Int32 => unchecked((ulong)(int)value),
+            TypeCode.UInt64 => (ulong)value,
+            TypeCode.Int64 => unchecked((ulong)(long)value),
+            _ => throw new ArgumentException("Bit operations require an integral PLC tag type.", nameof(tagType)),
+        };
+    }
+
+    private static object ConvertUnsignedIntegralValue(ulong value, Type tagType) => Type.GetTypeCode(tagType) switch
+    {
+        TypeCode.Byte => unchecked((byte)value),
+        TypeCode.SByte => unchecked((sbyte)value),
+        TypeCode.UInt16 => unchecked((ushort)value),
+        TypeCode.Int16 => unchecked((short)value),
+        TypeCode.UInt32 => unchecked((uint)value),
+        TypeCode.Int32 => unchecked((int)value),
+        TypeCode.UInt64 => value,
+        TypeCode.Int64 => unchecked((long)value),
+        _ => throw new ArgumentException("Bit operations require an integral PLC tag type.", nameof(tagType)),
+    };
 }

--- a/src/ABPlcRx/ABPlcRx.csproj
+++ b/src/ABPlcRx/ABPlcRx.csproj
@@ -21,5 +21,27 @@
   <ItemGroup Condition="!$(TargetFramework.StartsWith('netstandard2'))">
     <PackageReference Include="ReactiveUI.Extensions" Version="4.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ABPlcRx.SourceGenerators\ABPlcRx.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all"
+                      SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
+  <Target Name="PackSourceGeneratorAnalyzer" BeforeTargets="_GetPackageFiles">
+    <PropertyGroup>
+      <_ABPlcRxSourceGeneratorPath>$(MSBuildProjectDirectory)\..\ABPlcRx.SourceGenerators\bin\$(Configuration)\netstandard2.0\ABPlcRx.SourceGenerators.dll</_ABPlcRxSourceGeneratorPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <None Include="$(_ABPlcRxSourceGeneratorPath)"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false"
+            Condition="Exists('$(_ABPlcRxSourceGeneratorPath)')" />
+    </ItemGroup>
+  </Target>
   
 </Project>

--- a/src/ABPlcRx/Core/DataLength.cs
+++ b/src/ABPlcRx/Core/DataLength.cs
@@ -71,6 +71,7 @@ internal static class DataLength
     /// </value>
     public static IReadOnlyDictionary<Type, int> NativeTypes { get; } = new Dictionary<Type, int>
     {
+        { typeof(bool), UINT8 },
         { typeof(long), INT64 },
         { typeof(ulong), UINT64 },
         { typeof(int), INT32 },

--- a/src/ABPlcRx/Core/PlcTagWrapper.cs
+++ b/src/ABPlcRx/Core/PlcTagWrapper.cs
@@ -44,6 +44,13 @@ public class PlcTagWrapper
     public string GetBitsString() => new([.. GetBits().Cast<bool>().Select(a => a ? '1' : '0')]);
 
     /// <summary>
+    /// Get local value Bool.
+    /// </summary>
+    /// <param name="offset">The offset.</param>
+    /// <returns>A Value.</returns>
+    public bool GetBool(int offset = 0) => GetUInt8(offset) != 0;
+
+    /// <summary>
     /// Get local value Float32.
     /// </summary>
     /// <param name="offset">The offset.</param>
@@ -194,6 +201,13 @@ public class PlcTagWrapper
         bits.CopyTo(data, 0);
         Set(data[0]);
     }
+
+    /// <summary>
+    /// Set local value Bool.
+    /// </summary>
+    /// <param name="value">if set to <c>true</c> [value].</param>
+    /// <param name="offset">The offset.</param>
+    public void SetBool(bool value, int offset = 0) => SetUInt8(value ? (byte)1 : (byte)0, offset);
 
     /// <summary>
     /// Set local value Float32.
@@ -374,6 +388,10 @@ public class PlcTagWrapper
         {
             return GetUInt8(offset);
         }
+        else if (type == typeof(bool))
+        {
+            return GetBool(offset);
+        }
         else if (type == typeof(float))
         {
             return GetFloat32(offset);
@@ -450,6 +468,10 @@ public class PlcTagWrapper
         {
             SetUInt8((byte)value, offset);
         }
+        else if (type == typeof(bool))
+        {
+            SetBool((bool)value, offset);
+        }
         else if (type == typeof(float))
         {
             SetFloat32((float)value, offset);
@@ -474,6 +496,7 @@ public class PlcTagWrapper
 
     private object? GetNumericValue(int offset = 0) => Type.GetTypeCode(_tag.TypeValue) switch
     {
+        TypeCode.Boolean => GetBool(offset),
         TypeCode.Byte => GetUInt8(offset),
         TypeCode.SByte => GetInt8(offset),
         TypeCode.UInt16 => GetUInt16(offset),

--- a/src/ABPlcRx/IABPlcRx.cs
+++ b/src/ABPlcRx/IABPlcRx.cs
@@ -58,7 +58,6 @@ public interface IABPlcRx : ICancelable
     /// <typeparam name="T">The tag type.</typeparam>
     /// <param name="tagName">Name of the PLC tag.</param>
     /// <exception cref="System.ArgumentNullException">tagName.</exception>
-    /// <exception cref="System.Exception">Please use type of short, then use bool for other operations and set the bit number.</exception>
     void AddUpdateTagItem<T>(string tagName);
 
     /// <summary>
@@ -68,7 +67,6 @@ public interface IABPlcRx : ICancelable
     /// <param name="variable">The variable, this can be any non null name you wish to use.</param>
     /// <param name="tagName">Name of the plc tag.</param>
     /// <exception cref="System.ArgumentNullException">tagName.</exception>
-    /// <exception cref="System.Exception">Please use type of short, then use bool for other operations and set the bit number.</exception>
     void AddUpdateTagItem<T>(string variable, string tagName);
 
     /// <summary>
@@ -79,7 +77,6 @@ public interface IABPlcRx : ICancelable
     /// <param name="tagName">Name of the plc tag.</param>
     /// <param name="tagGroup">The tag group.</param>
     /// <exception cref="System.ArgumentNullException">tagName.</exception>
-    /// <exception cref="System.Exception">Please use type of short, then use bool for other operations and set the bit number.</exception>
     void AddUpdateTagItem<T>(string variable, string tagName, string tagGroup);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fixes issue [#79](https://github.com/ChrisPulman/ABPlcRx/issues/79) by allowing direct `bool` tags for Logix/CompactLogix/Micro800 BOOL variables instead of forcing all boolean access through `short` bit operations.
- Keeps SLC/PLC word-bit access working via `short` plus `bit`, while distinguishing native BOOL tags from bit-addressed tags in the generator output.
- Packs `ABPlcRx.SourceGenerators.dll` inside the main `ABPlcRx` NuGet package under `analyzers/dotnet/cs`, so consumers get the generator automatically.
- Updated the README to show the intended BOOL usage and the bundled generator behavior.

## Testing
- Added and updated unit coverage for native `bool` tag handling, reactive surface behavior, async observable wrappers, and source generator output.
- `dotnet test src/ABPlcRx.sln` passed across `net8.0`, `net9.0`, and `net10.0`.
- `dotnet pack src/ABPlcRx/ABPlcRx.csproj -o artifacts/packages` succeeded, and the generated package was verified to contain the analyzer assembly.