### PR TITLE
Fix GitHub Actions compile race in source generator build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -61,6 +61,7 @@ partial class Build : NukeBuild
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .SetProperty("BuildInParallel", "false")
+                .SetProperty("UseSharedCompilation", "false")
                 .EnableNoRestore()));
 
     Target Pack => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -60,6 +60,7 @@ partial class Build : NukeBuild
         .Executes(() => DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
+                .SetProperty("BuildInParallel", "false")
                 .EnableNoRestore()));
 
     Target Pack => _ => _


### PR DESCRIPTION
## Why
The `BuildDeploy` workflow failed during `Compile` with `CS2012` because `ABPlcRx.SourceGenerators.dll` was being written concurrently. This prevented the pipeline from reaching pack and publish.

## What changed
The NUKE `Compile` target now sets `BuildInParallel=false` for the solution build. This removes the MSBuild project-level parallel write race that intermittently locked the source generator output on `windows-latest`.

## Notes
This is a targeted CI stability fix in the build orchestration only. Package build and publish flow remain unchanged once compile completes.