### PR TITLE
Fix NuGet deploy readme path and harden CI compile

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <NoWarn>CS1591;IDE0190;IDE1006</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Configurations>Debug;Release</Configurations>
     <PackageReleaseNotes>Compatability with Net 8/ 9/ 10 and netstandard2.0</PackageReleaseNotes>
     <PackageTags>Rockwell;AB;Allen;Bradley;PLC;Micrologix;Controllogix;CompactLogix;PLC-5;rx;reactive;extensions;observable;LINQ;net;netstandard</PackageTags>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -61,6 +61,7 @@ partial class Build : NukeBuild
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .SetProperty("BuildInParallel", "false")
+                .SetProperty("UseSharedCompilation", "false")
                 .EnableNoRestore()));
 
     Target Pack => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -60,6 +60,7 @@ partial class Build : NukeBuild
         .Executes(() => DotNetBuild(s => s
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
+                .SetProperty("BuildInParallel", "false")
                 .EnableNoRestore()));
 
     Target Pack => _ => _


### PR DESCRIPTION
## Why
The previous merge left two follow-up fixes out of `main`: a NuGet packaging metadata mismatch that causes deploy rejection (`readme.md` not found), and an intermittent source-generator compile file-lock in CI.

## What changed
- Set `PackageReadmeFile` to `README.md` in `Directory.Build.props` so package metadata matches the actual packed file casing.
- Updated NUKE compile settings in `build/Build.cs` to reduce Roslyn/MSBuild lock contention:
  - `BuildInParallel=false`
  - `UseSharedCompilation=false`

## Result
This unblocks NuGet publish by ensuring the readme entry exists in produced packages and makes CI compile more stable for source generator outputs.