### PR TITLE
feat: add reactive ABPlcRx package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,10 @@
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <Features>$(Features);runtime-async=on</Features>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,7 +52,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleSharp.Analyzers" Version="3.17.9" PrivateAssets="all" />
+    <PackageReference Include="StyleSharp.Analyzers" Version="3.16.0" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/ABPlcRx.Reactive/ABPlcRx.Reactive.csproj
+++ b/src/ABPlcRx.Reactive/ABPlcRx.Reactive.csproj
@@ -1,16 +1,31 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net48;net481;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
+    <AssemblyName>ABPlcRx.Reactive</AssemblyName>
+    <PackageId>ABPlcRx.Reactive</PackageId>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM;REACTIVELIST_REACTIVE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ABPlcRx\**\*.cs"
+             Exclude="..\ABPlcRx\bin\**;..\ABPlcRx\obj\**"
+             LinkBase="ABPlcRx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Reactive.Unit" Alias="RxVoid" />
+    <Using Include="System.Reactive.Concurrency.IScheduler" Alias="ISequencer" />
+    <Using Include="System.Reactive.Concurrency.TaskPoolScheduler" Alias="TaskPoolSequencer" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="libplctag.NativeImport" Version="2.0.0-alpha.8" />
-    <PackageReference Include="ReactiveUI.Primitives" Version="6.0.0" />
-    <PackageReference Include="ReactiveUI.Primitives.Async" Version="6.0.0" />
-    <PackageReference Include="ReactiveUI.Primitives.Extensions" Version="6.0.0" />
+    <PackageReference Include="ReactiveUI.Primitives.Reactive" Version="6.0.0" />
+    <PackageReference Include="ReactiveUI.Primitives.Async.Reactive" Version="6.0.0" />
+    <PackageReference Include="ReactiveUI.Primitives.Extensions.Reactive" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,5 +55,5 @@
             Condition="Exists('$(_ABPlcRxSourceGeneratorPath)')" />
     </ItemGroup>
   </Target>
-  
+
 </Project>

--- a/src/ABPlcRx.Reactive/ABPlcRx.Reactive.csproj
+++ b/src/ABPlcRx.Reactive/ABPlcRx.Reactive.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net48;net481;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
@@ -16,6 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="ReactiveUI.Primitives.Async" />
+    <Using Include="ReactiveUI.Primitives.Signals" />
+    <Using Include="ReactiveUI.Primitives.Disposables" />
+    <Using Include="ReactiveUI.Primitives.Reactive" />
+    <Using Include="ReactiveUI.Primitives.Extensions.Reactive" />
     <Using Include="System.Reactive.Unit" Alias="RxVoid" />
     <Using Include="System.Reactive.Concurrency.IScheduler" Alias="ISequencer" />
     <Using Include="System.Reactive.Concurrency.TaskPoolScheduler" Alias="TaskPoolSequencer" />

--- a/src/ABPlcRx.SourceGenerators/PlcModelGenerator.cs
+++ b/src/ABPlcRx.SourceGenerators/PlcModelGenerator.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -17,11 +16,32 @@ namespace ABPlcRx.SourceGenerators;
 [Generator]
 public sealed class PlcModelGenerator : IIncrementalGenerator
 {
-    /// <summary>The fully qualified PLC model attribute metadata name.</summary>
-    private const string PlcModelAttributeName = "ABPlcRx.SourceGeneration.PlcModelAttribute";
+    /// <summary>The PLC model attribute type name.</summary>
+    private const string PlcModelAttributeName = "PlcModelAttribute";
 
-    /// <summary>The fully qualified PLC tag attribute metadata name.</summary>
-    private const string PlcTagAttributeName = "ABPlcRx.SourceGeneration.PlcTagAttribute";
+    /// <summary>The PLC tag attribute type name.</summary>
+    private const string PlcTagAttributeName = "PlcTagAttribute";
+
+    /// <summary>The source-generation namespace suffix appended to the runtime API namespace.</summary>
+    private const string SourceGenerationNamespaceSuffix = ".SourceGeneration";
+
+    /// <summary>The default runtime API namespace.</summary>
+    private const string DefaultApiNamespace = "ABPlcRx";
+
+    /// <summary>The System.Reactive-flavoured runtime API namespace.</summary>
+    private const string ReactiveApiNamespace = "ABPlcRx.Reactive";
+
+    /// <summary>The number of constructor arguments expected by class-level PLC tag attributes.</summary>
+    private const int ClassTagConstructorArgumentCount = 3;
+
+    /// <summary>The value-type argument index in class-level PLC tag attributes.</summary>
+    private const int ClassTagValueTypeArgumentIndex = 0;
+
+    /// <summary>The property-name argument index in class-level PLC tag attributes.</summary>
+    private const int ClassTagPropertyNameArgumentIndex = 1;
+
+    /// <summary>The tag-name argument index in class-level PLC tag attributes.</summary>
+    private const int ClassTagNameArgumentIndex = 2;
 
     /// <summary>The diagnostic descriptor used when a model type is not partial.</summary>
     private static readonly DiagnosticDescriptor PartialRequiredDescriptor = new(
@@ -63,8 +83,9 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
             return null;
         }
 
-        var tags = CollectTags(typeSymbol);
-        if (tags.Length == 0 && !HasAttribute(typeSymbol.GetAttributes(), PlcModelAttributeName))
+        var apiNamespace = GetApiNamespace(typeSymbol.GetAttributes(), PlcModelAttributeName);
+        var tags = CollectTags(typeSymbol, ref apiNamespace);
+        if (tags.Length == 0 && apiNamespace is null)
         {
             return null;
         }
@@ -80,7 +101,7 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
         }
 
         var hintName = $"{GetSafeHintName(typeSymbol)}.ABPlcRx.g.cs";
-        return GenerationResult.FromSource(hintName, GenerateModel(typeSymbol, tags));
+        return GenerationResult.FromSource(hintName, GenerateModel(typeSymbol, tags, apiNamespace ?? DefaultApiNamespace));
     }
 
     /// <summary>Emits generated source or reports a candidate diagnostic.</summary>
@@ -99,13 +120,20 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
 
     /// <summary>Collects PLC tag metadata from class and property attributes.</summary>
     /// <param name="typeSymbol">The candidate type symbol.</param>
+    /// <param name="apiNamespace">The runtime API namespace resolved from source-generation attributes.</param>
     /// <returns>The collected tag models.</returns>
-    private static ImmutableArray<TagModel> CollectTags(INamedTypeSymbol typeSymbol)
+    private static ImmutableArray<TagModel> CollectTags(INamedTypeSymbol typeSymbol, ref string? apiNamespace)
     {
         var builder = ImmutableArray.CreateBuilder<TagModel>();
 
-        foreach (var attribute in typeSymbol.GetAttributes().Where(static x => IsAttribute(x, PlcTagAttributeName)))
+        foreach (var attribute in typeSymbol.GetAttributes())
         {
+            if (!TryGetApiNamespace(attribute, PlcTagAttributeName, out var tagApiNamespace))
+            {
+                continue;
+            }
+
+            apiNamespace ??= tagApiNamespace;
             if (TryCreateClassTag(attribute, out var tag))
             {
                 builder.Add(tag);
@@ -114,8 +142,14 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
 
         foreach (var property in typeSymbol.GetMembers().OfType<IPropertySymbol>())
         {
-            foreach (var attribute in property.GetAttributes().Where(static x => IsAttribute(x, PlcTagAttributeName)))
+            foreach (var attribute in property.GetAttributes())
             {
+                if (!TryGetApiNamespace(attribute, PlcTagAttributeName, out var tagApiNamespace))
+                {
+                    continue;
+                }
+
+                apiNamespace ??= tagApiNamespace;
                 if (TryCreatePropertyTag(property, attribute, out var tag))
                 {
                     builder.Add(tag);
@@ -133,10 +167,10 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
     private static bool TryCreateClassTag(AttributeData attribute, out TagModel tag)
     {
         tag = default;
-        if (attribute.ConstructorArguments.Length != 3 ||
-            attribute.ConstructorArguments[0].Value is not ITypeSymbol valueType ||
-            attribute.ConstructorArguments[1].Value is not string propertyName ||
-            attribute.ConstructorArguments[2].Value is not string tagName ||
+        if (attribute.ConstructorArguments.Length != ClassTagConstructorArgumentCount ||
+            attribute.ConstructorArguments[ClassTagValueTypeArgumentIndex].Value is not ITypeSymbol valueType ||
+            attribute.ConstructorArguments[ClassTagPropertyNameArgumentIndex].Value is not string propertyName ||
+            attribute.ConstructorArguments[ClassTagNameArgumentIndex].Value is not string tagName ||
             string.IsNullOrWhiteSpace(propertyName) ||
             string.IsNullOrWhiteSpace(tagName))
         {
@@ -154,8 +188,7 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
             GetRegisterType(valueType, settings.Bit),
             settings.Bit,
             settings.RegisterTag,
-            generateProperty: true,
-            requiresValueGetOrDefault: false);
+            generateProperty: true);
         return true;
     }
 
@@ -186,8 +219,7 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
             GetRegisterType(valueType, settings.Bit),
             settings.Bit,
             settings.RegisterTag,
-            generateProperty: false,
-            requiresValueGetOrDefault: false);
+            generateProperty: false);
         return true;
     }
 
@@ -238,8 +270,9 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
     /// <summary>Generates the partial model source for collected tags.</summary>
     /// <param name="typeSymbol">The target type symbol.</param>
     /// <param name="tags">The tags to generate.</param>
+    /// <param name="apiNamespace">The runtime API namespace used by generated controller references.</param>
     /// <returns>The generated source text.</returns>
-    private static string GenerateModel(INamedTypeSymbol typeSymbol, ImmutableArray<TagModel> tags)
+    private static string GenerateModel(INamedTypeSymbol typeSymbol, ImmutableArray<TagModel> tags, string apiNamespace)
     {
         var builder = new StringBuilder();
         var namespaceName = typeSymbol.ContainingNamespace.IsGlobalNamespace ? null : typeSymbol.ContainingNamespace.ToDisplayString();
@@ -247,7 +280,9 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
         _ = builder.AppendLine("// <auto-generated />");
         _ = builder.AppendLine("#nullable enable");
         _ = builder.AppendLine("using System;");
-        _ = builder.AppendLine("using ReactiveUI.Primitives;");
+        _ = apiNamespace == ReactiveApiNamespace
+            ? builder.AppendLine("using ReactiveUI.Primitives.Reactive;")
+            : builder.AppendLine("using ReactiveUI.Primitives;");
         _ = builder.AppendLine();
 
         if (!string.IsNullOrWhiteSpace(namespaceName))
@@ -259,16 +294,17 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
         _ = builder.Append("partial class ").AppendLine(typeSymbol.Name);
         _ = builder.AppendLine("{");
         _ = builder.AppendLine("    private readonly global::ReactiveUI.Primitives.Disposables.MultipleDisposable _abPlcRxSubscriptions = new();");
-        _ = builder.AppendLine("    private global::ABPlcRx.IABPlcRx? _abPlcRxController;");
+        _ = builder.Append("    private global::").Append(apiNamespace).AppendLine(".IABPlcRx? _abPlcRxController;");
         _ = builder.AppendLine();
 
         foreach (var tag in tags)
         {
-            AppendTagMembers(builder, tag);
+            AppendTagMembers(builder, tag, apiNamespace);
         }
 
-        AppendAttachMethod(builder, tags);
+        AppendAttachMethod(builder, tags, apiNamespace);
         AppendDetachMethod(builder, tags);
+        AppendObserverType(builder);
 
         _ = builder.AppendLine("}");
         return builder.ToString();
@@ -277,7 +313,8 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
     /// <summary>Appends properties and observable accessors for one tag.</summary>
     /// <param name="builder">The target source builder.</param>
     /// <param name="tag">The tag model.</param>
-    private static void AppendTagMembers(StringBuilder builder, TagModel tag)
+    /// <param name="apiNamespace">The runtime API namespace used by generated controller references.</param>
+    private static void AppendTagMembers(StringBuilder builder, TagModel tag, string apiNamespace)
     {
         var fieldName = "_" + ToCamelCase(SanitizeIdentifier(tag.PropertyName));
         var observableFieldName = fieldName + "Observable";
@@ -303,7 +340,7 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
         _ = builder.AppendLine("#if NET8_0_OR_GREATER");
         _ = builder.Append("    public global::ReactiveUI.Primitives.Async.IObservableAsync<").Append(tag.ObserveType).Append("> ")
             .Append(tag.PropertyName).AppendLine("ObservableAsync =>");
-        _ = builder.Append("        global::ABPlcRx.ObservableAsyncBridgeExtensions.ToAsyncObservable(")
+        _ = builder.Append("        global::").Append(apiNamespace).Append(".ObservableAsyncBridgeExtensions.ToAsyncObservable(")
             .Append(tag.PropertyName).AppendLine("Observable);");
         _ = builder.AppendLine("#endif");
         _ = builder.AppendLine();
@@ -312,9 +349,10 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
     /// <summary>Appends the AttachPlcStreams method.</summary>
     /// <param name="builder">The target source builder.</param>
     /// <param name="tags">The generated tags.</param>
-    private static void AppendAttachMethod(StringBuilder builder, ImmutableArray<TagModel> tags)
+    /// <param name="apiNamespace">The runtime API namespace used by generated controller references.</param>
+    private static void AppendAttachMethod(StringBuilder builder, ImmutableArray<TagModel> tags, string apiNamespace)
     {
-        _ = builder.AppendLine("    public global::System.IDisposable AttachPlcStreams(global::ABPlcRx.IABPlcRx controller)");
+        _ = builder.Append("    public global::System.IDisposable AttachPlcStreams(global::").Append(apiNamespace).AppendLine(".IABPlcRx controller)");
         _ = builder.AppendLine("    {");
         _ = builder.AppendLine("        if (controller is null)");
         _ = builder.AppendLine("        {");
@@ -339,15 +377,9 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
             _ = builder.Append("        ").Append(observableFieldName).Append(" = controller.Observe<").Append(tag.ObserveType).Append(">(")
                 .Append(ToLiteral(tag.Variable)).Append(", ").Append(tag.Bit.ToString(System.Globalization.CultureInfo.InvariantCulture))
                 .AppendLine(").Publish().RefCount();");
-            _ = builder.Append("        _abPlcRxSubscriptions.Add(").Append(observableFieldName).Append(".Subscribe(value => ");
-            if (tag.RequiresValueGetOrDefault)
-            {
-                _ = builder.Append(tag.PropertyName).AppendLine(" = value.GetValueOrDefault()));");
-            }
-            else
-            {
-                _ = builder.Append(tag.PropertyName).AppendLine(" = value));");
-            }
+            _ = builder.Append("        _abPlcRxSubscriptions.Add(").Append(observableFieldName).Append(".Subscribe(new AbPlcRxObserver<")
+                .Append(tag.ObserveType).Append(">(value => ");
+            _ = builder.Append(tag.PropertyName).AppendLine(" = value)));");
         }
 
         _ = builder.AppendLine();
@@ -374,19 +406,71 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
         _ = builder.AppendLine("    }");
     }
 
-    /// <summary>Checks whether an attribute collection contains a metadata name.</summary>
-    /// <param name="attributes">The attribute collection.</param>
-    /// <param name="metadataName">The metadata name.</param>
-    /// <returns>True when the metadata name is present.</returns>
-    private static bool HasAttribute(ImmutableArray<AttributeData> attributes, string metadataName) =>
-        attributes.Any(attribute => IsAttribute(attribute, metadataName));
+    /// <summary>Appends the generated observer wrapper type.</summary>
+    /// <param name="builder">The target source builder.</param>
+    private static void AppendObserverType(StringBuilder builder)
+    {
+        _ = builder.AppendLine();
+        _ = builder.AppendLine("    private sealed class AbPlcRxObserver<T>(global::System.Action<T> onNext) : global::System.IObserver<T>");
+        _ = builder.AppendLine("    {");
+        _ = builder.AppendLine("        public void OnCompleted()");
+        _ = builder.AppendLine("        {");
+        _ = builder.AppendLine("        }");
+        _ = builder.AppendLine();
+        _ = builder.AppendLine("        public void OnError(global::System.Exception error)");
+        _ = builder.AppendLine("        {");
+        _ = builder.AppendLine("        }");
+        _ = builder.AppendLine();
+        _ = builder.AppendLine("        public void OnNext(T value) => onNext(value);");
+        _ = builder.AppendLine("    }");
+    }
 
-    /// <summary>Checks whether an attribute matches a metadata name.</summary>
+    /// <summary>Gets the runtime API namespace from an attribute collection.</summary>
+    /// <param name="attributes">The attributes to inspect.</param>
+    /// <param name="attributeName">The attribute type name.</param>
+    /// <returns>The runtime API namespace, or null.</returns>
+    private static string? GetApiNamespace(ImmutableArray<AttributeData> attributes, string attributeName)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (TryGetApiNamespace(attribute, attributeName, out var apiNamespace))
+            {
+                return apiNamespace;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Gets the runtime API namespace from one source-generation attribute.</summary>
     /// <param name="attribute">The attribute data.</param>
-    /// <param name="metadataName">The metadata name.</param>
-    /// <returns>True when the attribute matches.</returns>
-    private static bool IsAttribute(AttributeData attribute, string metadataName) =>
-        attribute.AttributeClass?.ToDisplayString() == metadataName;
+    /// <param name="attributeName">The attribute type name.</param>
+    /// <param name="apiNamespace">The resolved runtime API namespace.</param>
+    /// <returns>True when the attribute belongs to an ABPlcRx API namespace.</returns>
+    private static bool TryGetApiNamespace(AttributeData attribute, string attributeName, out string apiNamespace)
+    {
+        apiNamespace = string.Empty;
+        var attributeClass = attribute.AttributeClass;
+        if (attributeClass?.Name != attributeName)
+        {
+            return false;
+        }
+
+        var sourceGenerationNamespace = attributeClass.ContainingNamespace.ToDisplayString();
+        if (!sourceGenerationNamespace.EndsWith(SourceGenerationNamespaceSuffix, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var candidateApiNamespace = sourceGenerationNamespace.Substring(0, sourceGenerationNamespace.Length - SourceGenerationNamespaceSuffix.Length);
+        if (candidateApiNamespace is not (DefaultApiNamespace or ReactiveApiNamespace))
+        {
+            return false;
+        }
+
+        apiNamespace = candidateApiNamespace;
+        return true;
+    }
 
     /// <summary>Checks whether a type declaration is partial.</summary>
     /// <param name="declaration">The declaration.</param>
@@ -535,7 +619,6 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
         /// <param name="bit">The configured bit index.</param>
         /// <param name="registerTag">A value indicating whether to register the tag.</param>
         /// <param name="generateProperty">A value indicating whether to generate a property.</param>
-        /// <param name="requiresValueGetOrDefault">A value indicating whether nullable values need default conversion.</param>
         public TagModel(
             string propertyName,
             string variable,
@@ -546,8 +629,7 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
             string registerType,
             int bit,
             bool registerTag,
-            bool generateProperty,
-            bool requiresValueGetOrDefault)
+            bool generateProperty)
         {
             PropertyName = SanitizeIdentifier(propertyName);
             Variable = variable;
@@ -559,7 +641,6 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
             Bit = bit;
             RegisterTag = registerTag;
             GenerateProperty = generateProperty;
-            RequiresValueGetOrDefault = requiresValueGetOrDefault;
         }
 
         /// <summary>Gets the generated property name.</summary>
@@ -591,9 +672,6 @@ public sealed class PlcModelGenerator : IIncrementalGenerator
 
         /// <summary>Gets a value indicating whether a backing property should be generated.</summary>
         public bool GenerateProperty { get; }
-
-        /// <summary>Gets a value indicating whether nullable values need default conversion.</summary>
-        public bool RequiresValueGetOrDefault { get; }
     }
 
     /// <summary>Stores optional tag settings read from attribute arguments.</summary>

--- a/src/ABPlcRx.TestApp/Program.cs
+++ b/src/ABPlcRx.TestApp/Program.cs
@@ -13,6 +13,9 @@ namespace ABPlcRx.TestApp;
 /// <summary>Console sample application entry point.</summary>
 internal static class Program
 {
+    /// <summary>Sample PLC polling interval in milliseconds.</summary>
+    private const int PollIntervalMilliseconds = 500;
+
     /// <summary>Tracks sample application subscriptions.</summary>
     private static MultipleDisposable _disposables = new();
 
@@ -38,7 +41,7 @@ internal static class Program
         _disposables.Add(Signal.Timer(TimeSpan.FromSeconds(1)).Subscribe(initialTick =>
         {
             // Create PLC
-            var microLogix = new ABPlcRx(PlcType.SLC, "172.16.17.4", TimeSpan.FromMilliseconds(500));
+            var microLogix = new ABPlcRx(PlcType.SLC, "172.16.17.4", TimeSpan.FromMilliseconds(PollIntervalMilliseconds));
             _disposables.Add(microLogix);
 
             // Disable Auto Write NOTE: defaults to true.

--- a/src/ABPlcRx.Tests/ABPlcRx.Tests.csproj
+++ b/src/ABPlcRx.Tests/ABPlcRx.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ABPlcRx.Reactive\ABPlcRx.Reactive.csproj" />
     <ProjectReference Include="..\ABPlcRx\ABPlcRx.csproj" />
     <ProjectReference Include="..\ABPlcRx.SourceGenerators\ABPlcRx.SourceGenerators.csproj" />
   </ItemGroup>

--- a/src/ABPlcRx.Tests/CoreBehaviorTests.cs
+++ b/src/ABPlcRx.Tests/CoreBehaviorTests.cs
@@ -13,6 +13,57 @@ namespace ABPlcRx.Tests;
 /// <summary>Tests core PLC helper behavior that does not require a live controller.</summary>
 public sealed class CoreBehaviorTests
 {
+    /// <summary>Sample collection size used by object-creation tests.</summary>
+    private const int SampleCollectionLength = 3;
+
+    /// <summary>Known integer value containing bit one.</summary>
+    private const int BitOneValue = 2;
+
+    /// <summary>Largest unsigned 8-bit value.</summary>
+    private const int ByteMaxIntegerValue = 255;
+
+    /// <summary>Shared raw maximum for scaling tests.</summary>
+    private const double RawMaximum = 100d;
+
+    /// <summary>Shared scaled maximum for validation tests.</summary>
+    private const double ScaleMaximum = 10d;
+
+    /// <summary>Input value for linear scaling tests.</summary>
+    private const double LinearRawValue = 50d;
+
+    /// <summary>Expected linear scaling result.</summary>
+    private const double LinearExpectedValue = 5d;
+
+    /// <summary>Invalid raw minimum used to force reversed range validation.</summary>
+    private const double InvalidRawMinimum = 2d;
+
+    /// <summary>Input value for square-root scaling tests.</summary>
+    private const double SquareRootRawValue = 25d;
+
+    /// <summary>Expected square-root scaling result.</summary>
+    private const double SquareRootExpectedValue = 50d;
+
+    /// <summary>Representative positive integral value used by conversion tests.</summary>
+    private const byte PositiveByteValue = 42;
+
+    /// <summary>Representative positive 16-bit value used by conversion tests.</summary>
+    private const ushort PositiveUInt16Value = 42;
+
+    /// <summary>Representative positive 32-bit value used by conversion tests.</summary>
+    private const uint PositiveUInt32Value = 42U;
+
+    /// <summary>Representative positive 64-bit value used by conversion tests.</summary>
+    private const ulong PositiveUInt64Value = 42UL;
+
+    /// <summary>Last valid byte bit index.</summary>
+    private const int LastByteBit = 7;
+
+    /// <summary>Last valid short bit index.</summary>
+    private const int LastShortBit = 15;
+
+    /// <summary>Number of bits in a byte.</summary>
+    private const int ByteBitWidth = 8;
+
     /// <summary>Verifies object creation normalizes nested strings.</summary>
     /// <returns><see cref="Task"/> representing the test.</returns>
     [Test]
@@ -31,9 +82,9 @@ public sealed class CoreBehaviorTests
     [Test]
     internal async Task CreateObjectCreatesStringArraysWithEmptyEntriesAsync()
     {
-        var values = TagHelper.CreateObject<string[]>(3);
+        var values = TagHelper.CreateObject<string[]>(SampleCollectionLength);
 
-        await Assert.That(values.Length).IsEqualTo(3);
+        await Assert.That(values.Length).IsEqualTo(SampleCollectionLength);
         await Assert.That(values.All(static value => value is { Length: 0 })).IsTrue();
     }
 
@@ -52,7 +103,7 @@ public sealed class CoreBehaviorTests
     [Test]
     internal async Task BitsRoundTripKnownValuesAsync()
     {
-        foreach (var value in new[] { 0, 1, 2, 255, -1 })
+        foreach (var value in new[] { 0, 1, BitOneValue, ByteMaxIntegerValue, -1 })
         {
             await Assert.That(TagHelper.BitsToNumber(TagHelper.NumberToBits(value))).IsEqualTo(value);
         }
@@ -87,12 +138,12 @@ public sealed class CoreBehaviorTests
     [Test]
     internal async Task ScaleLinearMapsRawRangeAndRejectsInvalidRangesAsync()
     {
-        var tag = new ScalingTag(50d);
+        var tag = new ScalingTag(LinearRawValue);
 
-        await Assert.That(TagHelper.ScaleLinear(tag, 0d, 100d, 0d, 10d)).IsEqualTo(5d);
-        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleLinear(tag, 1d, 1d, 0d, 10d));
-        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleLinear(tag, 2d, 1d, 0d, 10d));
-        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleLinear(tag, 0d, 100d, 10d, 0d));
+        await Assert.That(TagHelper.ScaleLinear(tag, 0d, RawMaximum, 0d, ScaleMaximum)).IsEqualTo(LinearExpectedValue);
+        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleLinear(tag, 1d, 1d, 0d, ScaleMaximum));
+        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleLinear(tag, InvalidRawMinimum, 1d, 0d, ScaleMaximum));
+        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleLinear(tag, 0d, RawMaximum, ScaleMaximum, 0d));
     }
 
     /// <summary>Verifies square-root scaling maps raw values and rejects invalid raw bounds.</summary>
@@ -100,12 +151,12 @@ public sealed class CoreBehaviorTests
     [Test]
     internal async Task ScaleSquareRootMapsRawRangeAndRejectsInvalidRangesAsync()
     {
-        var tag = new ScalingTag(25d);
+        var tag = new ScalingTag(SquareRootRawValue);
 
-        await Assert.That(TagHelper.ScaleSquareRoot(tag, 0d, 100d, 0d, 100d)).IsEqualTo(50d);
-        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleSquareRoot(tag, 1d, 1d, 0d, 10d));
-        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleSquareRoot(tag, 2d, 1d, 0d, 10d));
-        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleSquareRoot(tag, 0d, 100d, 10d, 0d));
+        await Assert.That(TagHelper.ScaleSquareRoot(tag, 0d, RawMaximum, 0d, RawMaximum)).IsEqualTo(SquareRootExpectedValue);
+        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleSquareRoot(tag, 1d, 1d, 0d, ScaleMaximum));
+        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleSquareRoot(tag, InvalidRawMinimum, 1d, 0d, ScaleMaximum));
+        _ = Assert.Throws<InvalidOperationException>(() => TagHelper.ScaleSquareRoot(tag, 0d, RawMaximum, ScaleMaximum, 0d));
     }
 
     /// <summary>Verifies private integral conversion helpers round-trip supported PLC value types.</summary>
@@ -113,22 +164,22 @@ public sealed class CoreBehaviorTests
     [Test]
     internal async Task IntegralBitConversionHelpersRoundTripSupportedTypesAsync()
     {
-        await Assert.That(GetUnsignedIntegralValue((byte)42, typeof(byte))).IsEqualTo(42UL);
+        await Assert.That(GetUnsignedIntegralValue(PositiveByteValue, typeof(byte))).IsEqualTo(PositiveUInt64Value);
         await Assert.That(GetUnsignedIntegralValue((sbyte)-1, typeof(sbyte))).IsEqualTo(byte.MaxValue);
-        await Assert.That(GetUnsignedIntegralValue((ushort)42, typeof(ushort))).IsEqualTo(42UL);
+        await Assert.That(GetUnsignedIntegralValue(PositiveUInt16Value, typeof(ushort))).IsEqualTo(PositiveUInt64Value);
         await Assert.That(GetUnsignedIntegralValue((short)-1, typeof(short))).IsEqualTo(ushort.MaxValue);
-        await Assert.That(GetUnsignedIntegralValue(42U, typeof(uint))).IsEqualTo(42UL);
+        await Assert.That(GetUnsignedIntegralValue(PositiveUInt32Value, typeof(uint))).IsEqualTo(PositiveUInt64Value);
         await Assert.That(GetUnsignedIntegralValue(-1, typeof(int))).IsEqualTo(uint.MaxValue);
-        await Assert.That(GetUnsignedIntegralValue(42UL, typeof(ulong))).IsEqualTo(42UL);
+        await Assert.That(GetUnsignedIntegralValue(PositiveUInt64Value, typeof(ulong))).IsEqualTo(PositiveUInt64Value);
         await Assert.That(GetUnsignedIntegralValue(-1L, typeof(long))).IsEqualTo(ulong.MaxValue);
 
-        await Assert.That(ConvertUnsignedIntegralValue(42UL, typeof(byte))).IsEqualTo((byte)42);
+        await Assert.That(ConvertUnsignedIntegralValue(PositiveUInt64Value, typeof(byte))).IsEqualTo(PositiveByteValue);
         await Assert.That(ConvertUnsignedIntegralValue(byte.MaxValue, typeof(sbyte))).IsEqualTo((sbyte)-1);
-        await Assert.That(ConvertUnsignedIntegralValue(42UL, typeof(ushort))).IsEqualTo((ushort)42);
+        await Assert.That(ConvertUnsignedIntegralValue(PositiveUInt64Value, typeof(ushort))).IsEqualTo(PositiveUInt16Value);
         await Assert.That(ConvertUnsignedIntegralValue(ushort.MaxValue, typeof(short))).IsEqualTo((short)-1);
-        await Assert.That(ConvertUnsignedIntegralValue(42UL, typeof(uint))).IsEqualTo(42U);
+        await Assert.That(ConvertUnsignedIntegralValue(PositiveUInt64Value, typeof(uint))).IsEqualTo(PositiveUInt32Value);
         await Assert.That(ConvertUnsignedIntegralValue(uint.MaxValue, typeof(int))).IsEqualTo(-1);
-        await Assert.That(ConvertUnsignedIntegralValue(42UL, typeof(ulong))).IsEqualTo(42UL);
+        await Assert.That(ConvertUnsignedIntegralValue(PositiveUInt64Value, typeof(ulong))).IsEqualTo(PositiveUInt64Value);
         await Assert.That(ConvertUnsignedIntegralValue(ulong.MaxValue, typeof(long))).IsEqualTo(-1L);
     }
 
@@ -137,10 +188,10 @@ public sealed class CoreBehaviorTests
     [Test]
     internal async Task BitIndexValidationRejectsInvalidTypesAndRangesAsync()
     {
-        await Assert.That(() => ValidateBitIndex(typeof(byte), 7)).ThrowsNothing();
-        await Assert.That(() => ValidateBitIndex(typeof(short), 15)).ThrowsNothing();
+        await Assert.That(() => ValidateBitIndex(typeof(byte), LastByteBit)).ThrowsNothing();
+        await Assert.That(() => ValidateBitIndex(typeof(short), LastShortBit)).ThrowsNothing();
         _ = Assert.Throws<ArgumentOutOfRangeException>(() => ValidateBitIndex(typeof(byte), -1));
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => ValidateBitIndex(typeof(byte), 8));
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => ValidateBitIndex(typeof(byte), ByteBitWidth));
         _ = Assert.Throws<ArgumentException>(() => ValidateBitIndex(typeof(bool), 0));
     }
 
@@ -223,7 +274,7 @@ public sealed class CoreBehaviorTests
 
         bool IPlcTag.ReadOnly { get; set; }
 
-        int IPlcTag.Size => 8;
+        int IPlcTag.Size => ByteBitWidth;
 
         Type IPlcTag.TypeValue => _value?.GetType() ?? typeof(double);
 
@@ -241,7 +292,7 @@ public sealed class CoreBehaviorTests
         {
         }
 
-        int IPlcTag.GetSize() => 8;
+        int IPlcTag.GetSize() => ByteBitWidth;
 
         int IPlcTag.GetStatus() => PlcTagStatus.StatusOK;
 

--- a/src/ABPlcRx.Tests/NativeTagBehaviorTests.cs
+++ b/src/ABPlcRx.Tests/NativeTagBehaviorTests.cs
@@ -1,0 +1,535 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using ReactiveUI.Primitives.Signals;
+using TUnit.Assertions;
+using TUnit.Core;
+
+namespace ABPlcRx.Tests;
+
+/// <summary>Tests PLC/tag behavior through a fake native adapter.</summary>
+public sealed class NativeTagBehaviorTests
+{
+    /// <summary>Fake native handle used by direct wrapper tests.</summary>
+    private const int DirectHandle = 901;
+
+    /// <summary>First fake native handle returned from create.</summary>
+    private const int FirstCreatedHandle = 1000;
+
+    /// <summary>Fake native buffer length.</summary>
+    private const int NativeBufferLength = 512;
+
+    /// <summary>Sample PLC timeout.</summary>
+    private const int OperationTimeout = 1234;
+
+    /// <summary>Test scan interval.</summary>
+    private const int ScanIntervalMilliseconds = 10_000;
+
+    /// <summary>Sample bit index.</summary>
+    private const int SampleBitIndex = 1;
+
+    /// <summary>Sample PLC array length.</summary>
+    private const int SampleArrayLength = 2;
+
+    /// <summary>Sample int value.</summary>
+    private const int SampleIntValue = 42;
+
+    /// <summary>Updated sample int value.</summary>
+    private const int UpdatedIntValue = 77;
+
+    /// <summary>Sample short value.</summary>
+    private const short SampleShortValue = 12;
+
+    /// <summary>Sample unsigned short value.</summary>
+    private const ushort SampleUInt16Value = 13;
+
+    /// <summary>Sample byte value.</summary>
+    private const byte SampleByteValue = 14;
+
+    /// <summary>Sample signed byte value.</summary>
+    private const sbyte SampleSByteValue = -5;
+
+    /// <summary>Sample unsigned int value.</summary>
+    private const uint SampleUInt32Value = 15U;
+
+    /// <summary>Sample long value.</summary>
+    private const long SampleLongValue = 16L;
+
+    /// <summary>Sample unsigned long value.</summary>
+    private const ulong SampleUInt64Value = 17UL;
+
+    /// <summary>Sample float value.</summary>
+    private const float SampleFloatValue = 18.5F;
+
+    /// <summary>Sample double value.</summary>
+    private const double SampleDoubleValue = 19.5D;
+
+    /// <summary>Secondary array value.</summary>
+    private const int SecondArrayValue = 64;
+
+    /// <summary>Offset used by typed wrapper tests.</summary>
+    private const int SecondaryOffset = 16;
+
+    /// <summary>Sample string value.</summary>
+    private const string SampleStringValue = "AB";
+
+    /// <summary>Verifies PLC group management and bulk operations use the fake native adapter.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ABPlcManagesGroupsTagsAndBulkOperationsAsync()
+    {
+        var native = new FakePlcTagNative();
+        using var plc = new ABPlc("127.0.0.1", PlcType.SLC, null, native)
+        {
+            Timeout = OperationTimeout,
+        };
+        var addedTags = new List<IPlcTag>();
+        var removedTags = new List<IPlcTag>();
+
+        using var addedSubscription = plc.TagsAdded.Subscribe(new CaptureObserver<IPlcTag>(addedTags.Add));
+        using var removedSubscription = plc.TagsRemoved.Subscribe(new CaptureObserver<IPlcTag>(removedTags.Add));
+
+        plc.AddTagToGroup<int>("Counter", "N7:0", TimeSpan.FromMilliseconds(ScanIntervalMilliseconds), "Fast");
+
+        await Assert.That(plc.HasTagGroup("Fast")).IsTrue();
+        await Assert.That(plc.TagCollectionList.Count).IsEqualTo(1);
+        await Assert.That(plc.TagCollectionList.Count).IsEqualTo(1);
+        await Assert.That(plc.Tags.Count).IsEqualTo(1);
+        await Assert.That(plc.TryGetPlcTag("Counter", out var tag)).IsTrue();
+        await Assert.That(plc.GetPlcTag("Counter")).IsEqualTo(tag);
+        await Assert.That(addedTags.Count).IsEqualTo(1);
+
+        var readResults = plc.ReadAll();
+        var writeResults = plc.WriteAll();
+        var asyncReadResults = await plc.ReadAllAsync();
+        var asyncWriteResults = await plc.WriteAllAsync();
+
+        await Assert.That(readResults.Count).IsEqualTo(1);
+        await Assert.That(writeResults.Count).IsEqualTo(1);
+        await Assert.That(asyncReadResults.Count).IsEqualTo(1);
+        await Assert.That(asyncWriteResults.Count).IsEqualTo(1);
+        await Assert.That(plc.RemoveTagGroup("Missing")).IsFalse();
+        await Assert.That(plc.RemoveTagGroup("Fast")).IsTrue();
+        await Assert.That(removedTags.Count).IsEqualTo(1);
+        await Assert.That(plc.HasTagGroup("Fast")).IsFalse();
+
+        plc.Dispose();
+
+        await Assert.That(native.DestroyCalls).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies tag arrays, removal, and collection validation paths.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcTagCollectionCreatesArraysAndValidatesRemovalAsync()
+    {
+        var native = new FakePlcTagNative();
+        using var plc = new ABPlc("127.0.0.1", PlcType.SLC, null, native);
+        var collection = plc.CreateTagList("Manual", TimeSpan.FromMilliseconds(ScanIntervalMilliseconds));
+
+        _ = Assert.Throws<ArgumentException>(() => collection.CreateTagArray<ArrayList>("Bad", "N7:0", 1));
+        _ = Assert.Throws<ArgumentException>(() => collection.CreateTagArray<int[]>("BadLength", "N7:0", 0));
+
+        var tag = collection.CreateTagArray<int[]>("Values", "N7:0", SampleArrayLength);
+        await Assert.That(collection.Tags.Count).IsEqualTo(1);
+
+        collection.RemoveTag(tag);
+
+        await Assert.That(collection.Tags.Count).IsEqualTo(0);
+        _ = Assert.Throws<ArgumentException>(() => collection.RemoveTag(tag));
+
+        collection.ClearTags();
+        collection.Dispose();
+        collection.Dispose();
+
+        await Assert.That(native.DestroyCalls).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies PLC tag lifecycle calls and error paths.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcTagUsesNativeAdapterForLifecycleAndErrorsAsync()
+    {
+        var native = new FakePlcTagNative();
+        using var plc = new ABPlc("10.0.0.5", PlcType.SLC, "1,0", native)
+        {
+            AutoWriteValue = true,
+            Timeout = OperationTimeout,
+        };
+        var observedResults = new List<PlcTagResult>();
+        var tag = new PlcTag<int>(plc, "Counter", "N7:0", DataLength.INT32);
+
+        using var subscription = tag.Changed.Subscribe(new CaptureObserver<PlcTagResult>(observedResults.Add));
+
+        tag.Value = SampleIntValue;
+        var readResult = tag.Read();
+
+        await Assert.That(native.LastCreatedUrl).Contains("gateway=10.0.0.5");
+        await Assert.That(native.LastCreatedUrl).Contains("path=1,0");
+        await Assert.That(native.LastCreatedUrl).Contains("elem_size=4");
+        await Assert.That(native.ReadInt32(tag.Handle)).IsEqualTo(SampleIntValue);
+        await Assert.That(native.LastWriteTimeout).IsEqualTo(OperationTimeout);
+        await Assert.That(native.LastReadTimeout).IsEqualTo(OperationTimeout);
+        await Assert.That(tag.IsWrite).IsTrue();
+        await Assert.That(tag.IsRead).IsTrue();
+        await Assert.That(readResult.Tag).IsEqualTo(tag);
+        await Assert.That(observedResults.Single()).IsEqualTo(readResult);
+        await Assert.That(tag.Abort()).IsEqualTo(PlcTagStatus.StatusOK);
+        await Assert.That(tag.GetSize()).IsEqualTo(NativeBufferLength);
+        await Assert.That(tag.GetStatus()).IsEqualTo(PlcTagStatus.StatusOK);
+        await Assert.That(tag.Lock()).IsEqualTo(PlcTagStatus.StatusOK);
+        await Assert.That(tag.Unlock()).IsEqualTo(PlcTagStatus.StatusOK);
+
+        tag.ReadOnly = true;
+        _ = Assert.Throws<InvalidOperationException>(() => tag.Write());
+        tag.ReadOnly = false;
+        plc.FailOperationRaiseException = true;
+        native.ReadStatusCode = PlcTagStatus.ErrBadParam;
+        _ = Assert.Throws<PlcTagException>(() => tag.Read());
+        native.ReadStatusCode = PlcTagStatus.StatusOK;
+        native.WriteStatusCode = PlcTagStatus.ErrBadParam;
+        _ = Assert.Throws<PlcTagException>(() => tag.Write());
+
+        tag.Dispose();
+        tag.Dispose();
+
+        await Assert.That(native.DestroyCalls).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies wrapper native value access and composite mapping.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcTagWrapperReadsWritesNativeValuesAndCompositeTypesAsync()
+    {
+        var native = new FakePlcTagNative();
+        native.EnsureHandle(DirectHandle);
+        var tag = new StubTag("Wrapper", DirectHandle, typeof(int), DataLength.INT32);
+        var wrapper = new PlcTagWrapper(tag, native);
+
+        wrapper.SetInt32(SampleIntValue);
+        await Assert.That(wrapper.GetInt32()).IsEqualTo(SampleIntValue);
+
+        wrapper.SetUInt32(SampleUInt32Value, SecondaryOffset);
+        await Assert.That(wrapper.GetUInt32(SecondaryOffset)).IsEqualTo(SampleUInt32Value);
+
+        wrapper.SetInt16(SampleShortValue);
+        await Assert.That(wrapper.GetInt16()).IsEqualTo(SampleShortValue);
+
+        wrapper.SetUInt16(SampleUInt16Value);
+        await Assert.That(wrapper.GetUInt16()).IsEqualTo(SampleUInt16Value);
+
+        wrapper.SetInt8(SampleSByteValue);
+        await Assert.That(wrapper.GetInt8()).IsEqualTo(SampleSByteValue);
+
+        wrapper.SetUInt8(SampleByteValue);
+        await Assert.That(wrapper.GetUInt8()).IsEqualTo(SampleByteValue);
+
+        wrapper.SetInt64(SampleLongValue);
+        await Assert.That(wrapper.GetInt64()).IsEqualTo(SampleLongValue);
+
+        wrapper.SetUInt64(SampleUInt64Value);
+        await Assert.That(wrapper.GetUInt64()).IsEqualTo(SampleUInt64Value);
+
+        wrapper.SetFloat32(SampleFloatValue);
+        await Assert.That(wrapper.GetFloat32()).IsEqualTo(SampleFloatValue);
+
+        wrapper.SetFloat64(SampleDoubleValue);
+        await Assert.That(wrapper.GetFloat64()).IsEqualTo(SampleDoubleValue);
+
+        wrapper.SetBool(true);
+        await Assert.That(wrapper.GetBool()).IsTrue();
+
+        wrapper.SetString(SampleStringValue);
+        await Assert.That(wrapper.GetString()).IsEqualTo(SampleStringValue);
+
+        wrapper.SetInt32(0);
+        wrapper.SetBit(SampleBitIndex, true);
+        await Assert.That(wrapper.GetBit(SampleBitIndex)).IsTrue();
+        await Assert.That(wrapper.GetBitsString()[SampleBitIndex]).IsEqualTo('1');
+
+        wrapper.SetBits(new BitArray([UpdatedIntValue]));
+        await Assert.That(wrapper.GetBitsArray().Length).IsGreaterThan(0);
+
+        var values = new[] { SampleIntValue, SecondArrayValue };
+        wrapper.Set(values);
+        var readResult = wrapper.Get(new int[values.Length]);
+        var readValues = readResult is int[] typedValues
+            ? typedValues
+            : throw new InvalidOperationException("Wrapper returned an unexpected array value.");
+
+        await Assert.That(readValues).IsEquivalentTo(values);
+
+        var composite = new WrapperComposite
+        {
+            Count = SampleIntValue,
+            Enabled = true,
+            Text = SampleStringValue,
+        };
+        wrapper.SetType(composite);
+        var readComposite = (WrapperComposite)wrapper.GetType(new WrapperComposite());
+
+        await Assert.That(readComposite.Count).IsEqualTo(composite.Count);
+        await Assert.That(readComposite.Enabled).IsEqualTo(composite.Enabled);
+        await Assert.That(readComposite.Text).IsEqualTo(composite.Text);
+        _ = Assert.Throws<ArgumentException>(() => wrapper.Set(DateTime.UtcNow));
+        _ = Assert.Throws<ArgumentException>(() => wrapper.Get(DateTime.UtcNow));
+
+        var invalidWrapper = new PlcTagWrapper(new StubTag("Invalid", DirectHandle, typeof(DateTime), DataLength.INT32), native);
+        _ = Assert.Throws<ArgumentException>(() => invalidWrapper.GetBit(0));
+    }
+
+    /// <summary>Verifies tag mixin helpers operate through typed PLC tags.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task TagMixinsOperateOnTypedPlcTagsAsync()
+    {
+        var native = new FakePlcTagNative();
+        using var plc = new ABPlc("127.0.0.1", PlcType.SLC, null, native)
+        {
+            AutoWriteValue = false,
+        };
+        using var tag = new PlcTag<short>(plc, "Flag", "B3:0", DataLength.INT16);
+
+        TagMixins.SetBit(tag, SampleBitIndex, true);
+
+        await Assert.That(TagMixins.GetBit(tag, SampleBitIndex)).IsTrue();
+        _ = Assert.Throws<ArgumentNullException>(() => TagMixins.SetBit(null!, SampleBitIndex, true));
+        _ = Assert.Throws<ArgumentNullException>(() => TagMixins.GetBit(null!, SampleBitIndex));
+        _ = Assert.Throws<ArgumentNullException>(() => TagHelper.ScaleLinear(null!, 0D, 1D, 0D, 1D));
+        _ = Assert.Throws<ArgumentNullException>(() => TagHelper.ScaleSquareRoot(null!, 0D, 1D, 0D, 1D));
+        _ = Assert.Throws<ArgumentNullException>(() => TagHelper.BitsToNumber(null!));
+        _ = Assert.Throws<InvalidOperationException>(() => DataLength.GetSizeObject(Array.Empty<int>()));
+        await Assert.That(PlcTagStatus.DecodeError(PlcTagStatus.StatusOK)).IsNotNull();
+    }
+
+    /// <summary>Observer that forwards values to an action.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    /// <param name="onNext">The action invoked for each value.</param>
+    private sealed class CaptureObserver<T>(Action<T> onNext) : IObserver<T>
+    {
+        /// <summary>Handles completion.</summary>
+        public void OnCompleted()
+        {
+        }
+
+        /// <summary>Handles errors.</summary>
+        /// <param name="error">The observed error.</param>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <summary>Handles values.</summary>
+        /// <param name="value">The observed value.</param>
+        public void OnNext(T value) => onNext(value);
+    }
+
+    /// <summary>Fake native adapter backed by in-memory buffers.</summary>
+    private sealed class FakePlcTagNative : IPlcTagNative
+    {
+        /// <summary>Native buffers keyed by handle.</summary>
+        private readonly Dictionary<int, byte[]> _buffers = [];
+
+        /// <summary>Next native handle.</summary>
+        private int _nextHandle = FirstCreatedHandle;
+
+        /// <summary>Gets or sets the read status code.</summary>
+        public int ReadStatusCode { get; set; } = PlcTagStatus.StatusOK;
+
+        /// <summary>Gets or sets the write status code.</summary>
+        public int WriteStatusCode { get; set; } = PlcTagStatus.StatusOK;
+
+        /// <summary>Gets the destroy call count.</summary>
+        public int DestroyCalls { get; private set; }
+
+        /// <summary>Gets the last created URL.</summary>
+        public string LastCreatedUrl { get; private set; } = string.Empty;
+
+        /// <summary>Gets the last read timeout.</summary>
+        public int LastReadTimeout { get; private set; }
+
+        /// <summary>Gets the last write timeout.</summary>
+        public int LastWriteTimeout { get; private set; }
+
+        /// <summary>Ensures a buffer exists for a handle.</summary>
+        /// <param name="handle">The native handle.</param>
+        public void EnsureHandle(int handle) => _ = GetBuffer(handle);
+
+        /// <summary>Reads a signed 32-bit value.</summary>
+        /// <param name="handle">The native handle.</param>
+        /// <returns>The value.</returns>
+        public int ReadInt32(int handle) => BitConverter.ToInt32(GetBuffer(handle), 0);
+
+        int IPlcTagNative.Abort(int handle) => PlcTagStatus.StatusOK;
+
+        int IPlcTagNative.Create(string url, int timeout)
+        {
+            LastCreatedUrl = url;
+            var handle = _nextHandle++;
+            _buffers.Add(handle, new byte[NativeBufferLength]);
+            return handle;
+        }
+
+        int IPlcTagNative.Destroy(int handle)
+        {
+            DestroyCalls++;
+            _ = _buffers.Remove(handle);
+            return PlcTagStatus.StatusOK;
+        }
+
+        float IPlcTagNative.GetFloat32(int handle, int offset) => BitConverter.ToSingle(GetBuffer(handle), offset);
+
+        double IPlcTagNative.GetFloat64(int handle, int offset) => BitConverter.ToDouble(GetBuffer(handle), offset);
+
+        short IPlcTagNative.GetInt16(int handle, int offset) => BitConverter.ToInt16(GetBuffer(handle), offset);
+
+        int IPlcTagNative.GetInt32(int handle, int offset) => BitConverter.ToInt32(GetBuffer(handle), offset);
+
+        long IPlcTagNative.GetInt64(int handle, int offset) => BitConverter.ToInt64(GetBuffer(handle), offset);
+
+        sbyte IPlcTagNative.GetInt8(int handle, int offset) => unchecked((sbyte)GetBuffer(handle)[offset]);
+
+        int IPlcTagNative.GetSize(int handle) => GetBuffer(handle).Length;
+
+        int IPlcTagNative.GetStatus(int handle) => PlcTagStatus.StatusOK;
+
+        ushort IPlcTagNative.GetUInt16(int handle, int offset) => BitConverter.ToUInt16(GetBuffer(handle), offset);
+
+        uint IPlcTagNative.GetUInt32(int handle, int offset) => BitConverter.ToUInt32(GetBuffer(handle), offset);
+
+        ulong IPlcTagNative.GetUInt64(int handle, int offset) => BitConverter.ToUInt64(GetBuffer(handle), offset);
+
+        byte IPlcTagNative.GetUInt8(int handle, int offset) => GetBuffer(handle)[offset];
+
+        int IPlcTagNative.Lock(int handle) => PlcTagStatus.StatusOK;
+
+        int IPlcTagNative.Read(int handle, int timeout)
+        {
+            LastReadTimeout = timeout;
+            return ReadStatusCode;
+        }
+
+        void IPlcTagNative.SetFloat32(int handle, int offset, float value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetFloat64(int handle, int offset, double value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetInt16(int handle, int offset, short value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetInt32(int handle, int offset, int value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetInt64(int handle, int offset, long value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetInt8(int handle, int offset, sbyte value) =>
+            GetBuffer(handle)[offset] = unchecked((byte)value);
+
+        void IPlcTagNative.SetUInt16(int handle, int offset, ushort value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetUInt32(int handle, int offset, uint value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetUInt64(int handle, int offset, ulong value) =>
+            WriteBytes(handle, offset, BitConverter.GetBytes(value));
+
+        void IPlcTagNative.SetUInt8(int handle, int offset, byte value) =>
+            GetBuffer(handle)[offset] = value;
+
+        int IPlcTagNative.Unlock(int handle) => PlcTagStatus.StatusOK;
+
+        int IPlcTagNative.Write(int handle, int timeout)
+        {
+            LastWriteTimeout = timeout;
+            return WriteStatusCode;
+        }
+
+        /// <summary>Gets a native buffer.</summary>
+        /// <param name="handle">The native handle.</param>
+        /// <returns>The buffer.</returns>
+        private byte[] GetBuffer(int handle)
+        {
+            if (!_buffers.TryGetValue(handle, out var buffer))
+            {
+                buffer = new byte[NativeBufferLength];
+                _buffers.Add(handle, buffer);
+            }
+
+            return buffer;
+        }
+
+        /// <summary>Writes bytes to a native buffer.</summary>
+        /// <param name="handle">The native handle.</param>
+        /// <param name="offset">The byte offset.</param>
+        /// <param name="bytes">The bytes to write.</param>
+        private void WriteBytes(int handle, int offset, byte[] bytes) =>
+            bytes.CopyTo(GetBuffer(handle), offset);
+    }
+
+    /// <summary>Composite value used by wrapper tests.</summary>
+    private sealed class WrapperComposite
+    {
+        /// <summary>Gets or sets the count.</summary>
+        public int Count { get; set; }
+
+        /// <summary>Gets or sets a value indicating whether the composite is enabled.</summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>Gets or sets the text.</summary>
+        public string Text { get; set; } = string.Empty;
+    }
+
+    /// <summary>PLC tag stub used by wrapper tests.</summary>
+    /// <param name="tagName">The tag name.</param>
+    /// <param name="handle">The fake native handle.</param>
+    /// <param name="typeValue">The PLC value type.</param>
+    /// <param name="size">The PLC element size.</param>
+    private sealed class StubTag(string tagName, int handle, Type typeValue, int size) : IPlcTag
+    {
+        IObservable<PlcTagResult> IPlcTag.Changed => Signal.Silent<PlcTagResult>();
+
+        int IPlcTag.Handle => handle;
+
+        bool IPlcTag.IsRead => false;
+
+        bool IPlcTag.IsWrite => false;
+
+        string IPlcTag.Variable => tagName;
+
+        int IPlcTag.Length => 1;
+
+        string IPlcTag.TagName => tagName;
+
+        bool IPlcTag.ReadOnly { get; set; }
+
+        int IPlcTag.Size => size;
+
+        Type IPlcTag.TypeValue => typeValue;
+
+        object? IPlcTag.Value { get; set; }
+
+        PlcTagWrapper IPlcTag.ValueManager => null!;
+
+        int IPlcTag.Abort() => PlcTagStatus.StatusOK;
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        int IPlcTag.GetSize() => size;
+
+        int IPlcTag.GetStatus() => PlcTagStatus.StatusOK;
+
+        int IPlcTag.Lock() => PlcTagStatus.StatusOK;
+
+        PlcTagResult IPlcTag.Read() => null!;
+
+        int IPlcTag.Unlock() => PlcTagStatus.StatusOK;
+
+        PlcTagResult IPlcTag.Write() => null!;
+    }
+}

--- a/src/ABPlcRx.Tests/ObservableAsyncBridgeTests.cs
+++ b/src/ABPlcRx.Tests/ObservableAsyncBridgeTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Async;
+using TUnit.Assertions;
+using TUnit.Core;
+
+namespace ABPlcRx.Tests;
+
+/// <summary>Tests synchronous-to-async observable bridge behavior.</summary>
+public sealed class ObservableAsyncBridgeTests
+{
+    /// <summary>Sample value forwarded by bridge tests.</summary>
+    private const int SampleValue = 42;
+
+    /// <summary>Verifies null source validation happens before adapter creation.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ToAsyncObservableRejectsNullSourceAsync()
+    {
+        _ = Assert.Throws<ArgumentNullException>(() => ObservableAsyncBridgeExtensions.ToAsyncObservable<int>(null!));
+        await Task.CompletedTask;
+    }
+
+    /// <summary>Verifies subscribe validation happens before source subscription.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ToAsyncObservableRejectsNullObserverAsync()
+    {
+        var source = new ManualObservable<int>();
+        var asyncObservable = ObservableAsyncBridgeExtensions.ToAsyncObservable(source);
+
+        _ = Assert.Throws<ArgumentNullException>(() => asyncObservable.SubscribeAsync(null!).AsTask().GetAwaiter().GetResult());
+        await Assert.That(source.SubscriberCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies cancellation is observed before source subscription.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ToAsyncObservableRejectsCanceledSubscriptionAsync()
+    {
+        var source = new ManualObservable<int>();
+        var asyncObservable = ObservableAsyncBridgeExtensions.ToAsyncObservable(source);
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        _ = Assert.Throws<OperationCanceledException>(() => asyncObservable.SubscribeAsync(new RecordingAsyncObserver<int>(), cancellation.Token).AsTask().GetAwaiter().GetResult());
+        await Assert.That(source.SubscriberCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies next, error, completion, and disposal are forwarded.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ToAsyncObservableForwardsNotificationsAndDisposalAsync()
+    {
+        var source = new ManualObservable<int>();
+        var observer = new RecordingAsyncObserver<int>();
+        var asyncObservable = ObservableAsyncBridgeExtensions.ToAsyncObservable(source);
+
+        var subscription = await asyncObservable.SubscribeAsync(observer, CancellationToken.None);
+        var error = new InvalidOperationException("bridge");
+
+        source.Next(SampleValue);
+        source.Error(error);
+        source.Completed();
+
+        await Assert.That(observer.Values).IsEquivalentTo([SampleValue]);
+        await Assert.That(observer.Error).IsEqualTo(error);
+        await Assert.That(observer.Completed).IsTrue();
+        await Assert.That(source.SubscriberCount).IsEqualTo(1);
+
+        await subscription.DisposeAsync();
+
+        await Assert.That(source.SubscriberCount).IsEqualTo(0);
+    }
+
+    /// <summary>Manual observable used to verify bridge subscription behavior.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class ManualObservable<T> : IObservable<T>
+    {
+        /// <summary>Active observers.</summary>
+        private readonly List<IObserver<T>> _observers = [];
+
+        /// <summary>Gets the number of active subscribers.</summary>
+        public int SubscriberCount => _observers.Count;
+
+        /// <inheritdoc/>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            _observers.Add(observer);
+            return new ActionDisposable(() => _ = _observers.Remove(observer));
+        }
+
+        /// <summary>Publishes a value.</summary>
+        /// <param name="value">The value.</param>
+        public void Next(T value)
+        {
+            foreach (var observer in _observers.ToArray())
+            {
+                observer.OnNext(value);
+            }
+        }
+
+        /// <summary>Publishes an error.</summary>
+        /// <param name="error">The error.</param>
+        public void Error(Exception error)
+        {
+            foreach (var observer in _observers.ToArray())
+            {
+                observer.OnError(error);
+            }
+        }
+
+        /// <summary>Publishes completion.</summary>
+        public void Completed()
+        {
+            foreach (var observer in _observers.ToArray())
+            {
+                observer.OnCompleted();
+            }
+        }
+    }
+
+    /// <summary>Records async observer notifications.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    private sealed class RecordingAsyncObserver<T> : IObserverAsync<T>
+    {
+        /// <summary>Gets observed values.</summary>
+        public List<T> Values { get; } = [];
+
+        /// <summary>Gets the observed error.</summary>
+        public Exception? Error { get; private set; }
+
+        /// <summary>Gets a value indicating whether completion was observed.</summary>
+        public bool Completed { get; private set; }
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync() => default;
+
+        /// <inheritdoc/>
+        public ValueTask OnCompletedAsync(Result result)
+        {
+            Completed = true;
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask OnErrorResumeAsync(Exception error, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Error = error;
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public ValueTask OnNextAsync(T value, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Values.Add(value);
+            return default;
+        }
+    }
+
+    /// <summary>Disposable wrapper for a teardown action.</summary>
+    /// <param name="dispose">The teardown action.</param>
+    private sealed class ActionDisposable(Action dispose) : IDisposable
+    {
+        /// <inheritdoc/>
+        public void Dispose() => dispose();
+    }
+}

--- a/src/ABPlcRx.Tests/ReactiveSurfaceTests.cs
+++ b/src/ABPlcRx.Tests/ReactiveSurfaceTests.cs
@@ -2,27 +2,42 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Async;
 using TUnit.Assertions;
 using TUnit.Core;
 using PlcController = ABPlcRx.ABPlcRx;
+using ReactiveIPlcTag = ABPlcRx.Reactive.IPlcTag;
+using ReactivePlcController = ABPlcRx.Reactive.ABPlcRx;
+using ReactivePlcTagResult = ABPlcRx.Reactive.PlcTagResult;
+using ReactivePlcType = ABPlcRx.Reactive.PlcType;
 
 namespace ABPlcRx.Tests;
 
 /// <summary>Tests the high-level reactive PLC facade.</summary>
 public sealed class ReactiveSurfaceTests
 {
+    /// <summary>Default test scan interval in milliseconds.</summary>
+    private const int TestScanIntervalMilliseconds = 10;
+
+    /// <summary>Timeout for synchronous observable completion in seconds.</summary>
+    private const int CompletionTimeoutSeconds = 5;
+
+    /// <summary>Sample interval used by sampled observable tests.</summary>
+    private const int SampleIntervalMilliseconds = 100;
+
+    /// <summary>Sample value used when writing to a missing variable.</summary>
+    private const int MissingVariableWriteValue = 42;
+
     /// <summary>Verifies an empty ObserveMany request emits an empty dictionary.</summary>
     /// <returns><see cref="Task"/> representing the test.</returns>
     [Test]
     internal async Task ObserveManyWithNoVariablesEmitsEmptyDictionaryAsync()
     {
-        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
         var completion = new TaskCompletionSource<IReadOnlyDictionary<string, object?>>();
 
-        using var subscription = plc.ObserveMany().Subscribe(completion.SetResult);
-        var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var subscription = plc.ObserveMany().Subscribe(new CaptureObserver<IReadOnlyDictionary<string, object?>>(completion.SetResult));
+        var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(CompletionTimeoutSeconds));
 
         await Assert.That(result.Count).IsEqualTo(0);
     }
@@ -32,7 +47,7 @@ public sealed class ReactiveSurfaceTests
     [Test]
     internal async Task AddUpdateTagItemValidationRunsBeforeNativeTagCreationAsync()
     {
-        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
 
         _ = Assert.Throws<ArgumentException>(() => plc.AddUpdateTagItem<int>(string.Empty, "N7:0", "Default"));
         _ = Assert.Throws<ArgumentException>(() => plc.AddUpdateTagItem<int>("Counter", string.Empty, "Default"));
@@ -46,13 +61,13 @@ public sealed class ReactiveSurfaceTests
     [Test]
     internal async Task AsyncObservableSurfaceWrapsExistingObservablePipelinesAsync()
     {
-        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
 
         await Assert.That(plc.ObserveAllAsyncObservable).IsAssignableTo<IObservableAsync<IPlcTag?>>();
         await Assert.That(plc.ObserveAsyncObservable<int>("Counter")).IsAssignableTo<IObservableAsync<int>>();
         await Assert.That(plc.ObserveManyAsyncObservable()).IsAssignableTo<IObservableAsync<IReadOnlyDictionary<string, object?>>>();
         await Assert.That(plc.ObserveGroupAsyncObservable("Default")).IsAssignableTo<IObservableAsync<IPlcTag>>();
-        await Assert.That(plc.ObserveSampledAsyncObservable<int>("Counter", TimeSpan.FromMilliseconds(100))).IsAssignableTo<IObservableAsync<int>>();
+        await Assert.That(plc.ObserveSampledAsyncObservable<int>("Counter", TimeSpan.FromMilliseconds(SampleIntervalMilliseconds))).IsAssignableTo<IObservableAsync<int>>();
         await Assert.That(plc.ObserveErrorsAsyncObservable()).IsAssignableTo<IObservableAsync<PlcTagResult>>();
         await Assert.That(plc.ObservePingAsyncObservable(TimeSpan.FromSeconds(1))).IsAssignableTo<IObservableAsync<bool>>();
     }
@@ -62,11 +77,11 @@ public sealed class ReactiveSurfaceTests
     [Test]
     internal async Task ValueReturnsDefaultForMissingVariableAsync()
     {
-        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
 
         await Assert.That(plc.Value<int>("Missing")).IsEqualTo(0);
         await Assert.That(plc.Value<string>("Missing")).IsNull();
-        await Assert.That(() => plc.Value("Missing", 42)).ThrowsNothing();
+        await Assert.That(() => plc.Value("Missing", MissingVariableWriteValue)).ThrowsNothing();
     }
 
     /// <summary>Verifies missing variables do not produce read or write results.</summary>
@@ -74,9 +89,87 @@ public sealed class ReactiveSurfaceTests
     [Test]
     internal async Task ReadWriteReturnNullForMissingVariableAsync()
     {
-        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(10));
+        using var plc = new PlcController(PlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
 
         await Assert.That(plc.Read("Missing")).IsNull();
         await Assert.That(plc.Write("Missing")).IsNull();
+    }
+
+    /// <summary>Verifies the System.Reactive-flavoured facade exposes the same empty-stream behavior.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ReactiveObserveManyWithNoVariablesEmitsEmptyDictionaryAsync()
+    {
+        using var plc = new ReactivePlcController(ReactivePlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
+        var completion = new TaskCompletionSource<IReadOnlyDictionary<string, object?>>();
+
+        using var subscription = plc.ObserveMany().Subscribe(new CaptureObserver<IReadOnlyDictionary<string, object?>>(completion.SetResult));
+        var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(CompletionTimeoutSeconds));
+
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies the System.Reactive-flavoured facade validates arguments before native tag creation.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ReactiveAddUpdateTagItemValidationRunsBeforeNativeTagCreationAsync()
+    {
+        using var plc = new ReactivePlcController(ReactivePlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
+
+        _ = Assert.Throws<ArgumentException>(() => plc.AddUpdateTagItem<int>(string.Empty, "N7:0", "Default"));
+        _ = Assert.Throws<ArgumentException>(() => plc.AddUpdateTagItem<int>("Counter", string.Empty, "Default"));
+        _ = Assert.Throws<ArgumentException>(() => plc.AddUpdateTagItem<int>("Counter", "N7:0", string.Empty));
+        await Assert.That(() => plc.AddUpdateTagItem<bool>("Flag", "BoolTest", "Default")).ThrowsNothing();
+    }
+
+    /// <summary>Verifies the System.Reactive-flavoured async surface wraps observable pipelines.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ReactiveAsyncObservableSurfaceWrapsExistingObservablePipelinesAsync()
+    {
+        using var plc = new ReactivePlcController(ReactivePlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
+
+        await Assert.That(plc.ObserveAllAsyncObservable).IsAssignableTo<IObservableAsync<ReactiveIPlcTag?>>();
+        await Assert.That(plc.ObserveAsyncObservable<int>("Counter")).IsAssignableTo<IObservableAsync<int>>();
+        await Assert.That(plc.ObserveManyAsyncObservable()).IsAssignableTo<IObservableAsync<IReadOnlyDictionary<string, object?>>>();
+        await Assert.That(plc.ObserveGroupAsyncObservable("Default")).IsAssignableTo<IObservableAsync<ReactiveIPlcTag>>();
+        await Assert.That(plc.ObserveSampledAsyncObservable<int>("Counter", TimeSpan.FromMilliseconds(SampleIntervalMilliseconds))).IsAssignableTo<IObservableAsync<int>>();
+        await Assert.That(plc.ObserveErrorsAsyncObservable()).IsAssignableTo<IObservableAsync<ReactivePlcTagResult>>();
+        await Assert.That(plc.ObservePingAsyncObservable(TimeSpan.FromSeconds(1))).IsAssignableTo<IObservableAsync<bool>>();
+    }
+
+    /// <summary>Verifies missing variables return defaults through the System.Reactive-flavoured facade.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task ReactiveMissingVariablesReturnDefaultsAsync()
+    {
+        using var plc = new ReactivePlcController(ReactivePlcType.SLC, "127.0.0.1", TimeSpan.FromMilliseconds(TestScanIntervalMilliseconds));
+
+        await Assert.That(plc.Value<int>("Missing")).IsEqualTo(0);
+        await Assert.That(plc.Value<string>("Missing")).IsNull();
+        await Assert.That(() => plc.Value("Missing", MissingVariableWriteValue)).ThrowsNothing();
+        await Assert.That(plc.Read("Missing")).IsNull();
+        await Assert.That(plc.Write("Missing")).IsNull();
+    }
+
+    /// <summary>Observer that forwards values to an action.</summary>
+    /// <typeparam name="T">The observed value type.</typeparam>
+    /// <param name="onNext">The action invoked for each value.</param>
+    private sealed class CaptureObserver<T>(Action<T> onNext) : IObserver<T>
+    {
+        /// <summary>Handles completion.</summary>
+        public void OnCompleted()
+        {
+        }
+
+        /// <summary>Handles errors.</summary>
+        /// <param name="error">The observed error.</param>
+        public void OnError(Exception error)
+        {
+        }
+
+        /// <summary>Handles values.</summary>
+        /// <param name="value">The observed value.</param>
+        public void OnNext(T value) => onNext(value);
     }
 }

--- a/src/ABPlcRx.Tests/SourceGeneratorTests.cs
+++ b/src/ABPlcRx.Tests/SourceGeneratorTests.cs
@@ -2,6 +2,7 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using ABPlcRx.SourceGeneration;
 using ABPlcRx.SourceGenerators;
 using Microsoft.CodeAnalysis;
@@ -11,6 +12,10 @@ using ReactiveUI.Primitives.Async;
 using ReactiveUI.Primitives.Disposables;
 using TUnit.Assertions;
 using TUnit.Core;
+using ReactiveAsyncContext = ReactiveUI.Primitives.Async.Reactive.AsyncContext;
+using ReactiveIABPlcRx = ABPlcRx.Reactive.IABPlcRx;
+using ReactiveLinqExtensions = ReactiveUI.Primitives.Reactive.LinqExtensions;
+using ReactivePlcModelAttribute = ABPlcRx.Reactive.SourceGeneration.PlcModelAttribute;
 
 namespace ABPlcRx.Tests;
 
@@ -36,21 +41,9 @@ public sealed class SourceGeneratorTests
             }
             """;
 
-        var compilation = CreateCompilation(source);
-        var generator = new PlcModelGenerator();
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(
-            [generator.AsSourceGenerator()],
-            parseOptions: new CSharpParseOptions(LanguageVersion.Preview));
-        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
-
-        await Assert.That(diagnostics.Any(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)).IsFalse();
-        await Assert.That(outputCompilation.GetDiagnostics().Any(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)).IsFalse();
-
-        var generatedTree = driver
-            .GetRunResult()
-            .GeneratedTrees
-            .Single(tree => tree.FilePath.EndsWith(".ABPlcRx.g.cs", StringComparison.Ordinal));
-        var generatedSource = (await generatedTree.GetTextAsync()).ToString();
+        var run = RunGenerator(source);
+        await AssertNoErrorsAsync(run);
+        var generatedSource = await GetGeneratedSourceAsync(run);
 
         await Assert.That(generatedSource).Contains("CounterObservable");
         await Assert.That(generatedSource).Contains("LightOnObservable");
@@ -65,10 +58,244 @@ public sealed class SourceGeneratorTests
         await Assert.That(generatedSource).Contains("controller.Observe<bool>(@\"Ready\", -1)");
     }
 
+    /// <summary>Verifies generated models bind to the reactive package namespace when reactive attributes are used.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorCreatesReactiveNamespaceModelsAsync()
+    {
+        const string source = """
+            using ABPlcRx.Reactive.SourceGeneration;
+
+            namespace GeneratedReactiveSample;
+
+            [PlcModel]
+            [PlcTag(typeof(int), "Counter", "MyDINT")]
+            public partial class ReactiveMachineTags
+            {
+            }
+            """;
+
+        var run = RunGenerator(source, reactive: true);
+        await AssertNoErrorsAsync(run);
+        var generatedSource = await GetGeneratedSourceAsync(run);
+
+        await Assert.That(generatedSource).Contains("using ReactiveUI.Primitives.Reactive;");
+        await Assert.That(generatedSource).Contains("global::ABPlcRx.Reactive.IABPlcRx");
+        await Assert.That(generatedSource).Contains("global::ABPlcRx.Reactive.ObservableAsyncBridgeExtensions.ToAsyncObservable");
+        await Assert.That(generatedSource).Contains("controller.AddUpdateTagItem<int>(@\"Counter\", @\"MyDINT\", @\"Default\")");
+    }
+
+    /// <summary>Verifies non-partial PLC models produce the expected diagnostic.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorReportsDiagnosticForNonPartialModelsAsync()
+    {
+        const string source = """
+            using ABPlcRx.SourceGeneration;
+
+            namespace GeneratedSample;
+
+            [PlcModel]
+            [PlcTag(typeof(int), "Counter", "MyDINT")]
+            public class MachineTags
+            {
+            }
+            """;
+
+        var run = RunGenerator(source);
+        var diagnostic = run.Diagnostics.Single(diagnostic => diagnostic.Id == "ABPLCRXSG001");
+
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Error);
+        await Assert.That(diagnostic.GetMessage()).Contains("MachineTags");
+        await Assert.That(run.Driver.GetRunResult().GeneratedTrees.Length).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies a model marker without tags does not emit source.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorSkipsModelsWithoutTagsAsync()
+    {
+        const string source = """
+            using ABPlcRx.SourceGeneration;
+
+            namespace GeneratedSample;
+
+            [PlcModel]
+            public partial class EmptyTags
+            {
+            }
+            """;
+
+        var run = RunGenerator(source);
+
+        await AssertNoErrorsAsync(run);
+        await Assert.That(run.Driver.GetRunResult().GeneratedTrees.Length).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies unrelated attributed types are ignored.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorIgnoresUnrelatedAttributesAsync()
+    {
+        const string source = """
+            namespace GeneratedSample;
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class OtherAttribute : System.Attribute
+            {
+            }
+
+            [Other]
+            public partial class IgnoredTags
+            {
+            }
+            """;
+
+        var run = RunGenerator(source);
+
+        await AssertNoErrorsAsync(run);
+        await Assert.That(run.Driver.GetRunResult().GeneratedTrees.Length).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies invalid ABPlcRx tag attributes are ignored without source output.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorIgnoresInvalidTagAttributesAsync()
+    {
+        const string source = """
+            using ABPlcRx.SourceGeneration;
+
+            namespace GeneratedSample;
+
+            [PlcModel]
+            [PlcTag(typeof(int), "", "N7:0")]
+            public partial class InvalidClassTags
+            {
+                [PlcTag("")]
+                public int InvalidProperty { get; private set; }
+            }
+            """;
+
+        var run = RunGenerator(source);
+
+        await AssertNoErrorsAsync(run);
+        await Assert.That(run.Driver.GetRunResult().GeneratedTrees.Length).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies attributes with matching names but unsupported namespaces are ignored.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorIgnoresUnsupportedAttributeNamespacesAsync()
+    {
+        const string source = """
+            namespace Other
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class)]
+                public sealed class PlcModelAttribute : System.Attribute
+                {
+                }
+            }
+
+            namespace External.SourceGeneration
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class)]
+                public sealed class PlcModelAttribute : System.Attribute
+                {
+                }
+            }
+
+            namespace GeneratedSample
+            {
+                [Other.PlcModel]
+                [External.SourceGeneration.PlcModel]
+                public partial class IgnoredTags
+                {
+                }
+            }
+            """;
+
+        var run = RunGenerator(source);
+
+        await AssertNoErrorsAsync(run);
+        await Assert.That(run.Driver.GetRunResult().GeneratedTrees.Length).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies property tags, custom settings, and identifier sanitization are emitted correctly.</summary>
+    /// <returns><see cref="Task"/> representing the test.</returns>
+    [Test]
+    internal async Task PlcModelGeneratorEmitsPropertyTagsAndCustomSettingsAsync()
+    {
+        const string source = """
+            using ABPlcRx.SourceGeneration;
+
+            namespace GeneratedSample;
+
+            [PlcModel]
+            [PlcTag(typeof(int), "1 Bad-Name", "Quoted\"Tag", Variable = "PLC Counter", Group = "Fast")]
+            public partial class MachineTags
+            {
+                [PlcTag("ExistingTag", Variable = "External Counter", Group = "Slow", RegisterTag = false)]
+                public int? ExternalCounter { get; private set; }
+            }
+            """;
+
+        var run = RunGenerator(source);
+        await AssertNoErrorsAsync(run);
+        var generatedSource = await GetGeneratedSourceAsync(run);
+
+        await Assert.That(generatedSource).Contains("public int _1_Bad_Name");
+        await Assert.That(generatedSource).Contains("controller.AddUpdateTagItem<int>(@\"PLC Counter\", @\"Quoted\"\"Tag\", @\"Fast\")");
+        await Assert.That(generatedSource).DoesNotContain("controller.AddUpdateTagItem<int>(@\"External Counter\"");
+        await Assert.That(generatedSource).Contains("controller.Observe<int>(@\"External Counter\", -1)");
+        await Assert.That(generatedSource).Contains("_externalCounterObservable");
+    }
+
+    /// <summary>Runs the source generator for a source snippet.</summary>
+    /// <param name="source">The source text.</param>
+    /// <param name="reactive">True to reference the reactive runtime surface.</param>
+    /// <returns>The generator run result.</returns>
+    private static GeneratorRun RunGenerator(string source, bool reactive = false)
+    {
+        var compilation = CreateCompilation(source, reactive);
+        var generator = new PlcModelGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [generator.AsSourceGenerator()],
+            parseOptions: new CSharpParseOptions(LanguageVersion.Preview));
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        return new(driver, outputCompilation, diagnostics);
+    }
+
+    /// <summary>Asserts that a generator run produced no compile or generator errors.</summary>
+    /// <param name="run">The generator run.</param>
+    /// <returns><see cref="Task"/> representing the assertion.</returns>
+    private static async Task AssertNoErrorsAsync(GeneratorRun run)
+    {
+        var generatorErrors = string.Join(Environment.NewLine, run.Diagnostics.Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        var outputErrors = string.Join(Environment.NewLine, run.OutputCompilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+
+        await Assert.That(generatorErrors).IsEqualTo(string.Empty);
+        await Assert.That(outputErrors).IsEqualTo(string.Empty);
+    }
+
+    /// <summary>Gets the generated source from a successful run.</summary>
+    /// <param name="run">The generator run.</param>
+    /// <returns>The generated source.</returns>
+    private static async Task<string> GetGeneratedSourceAsync(GeneratorRun run)
+    {
+        var generatedTree = run.Driver
+            .GetRunResult()
+            .GeneratedTrees
+            .Single(tree => tree.FilePath.EndsWith(".ABPlcRx.g.cs", StringComparison.Ordinal));
+
+        return (await generatedTree.GetTextAsync()).ToString();
+    }
+
     /// <summary>Creates a compilation for source generator tests.</summary>
     /// <param name="source">The source text.</param>
+    /// <param name="reactive">True to add explicit references to the reactive runtime surface.</param>
     /// <returns>The created compilation.</returns>
-    private static CSharpCompilation CreateCompilation(string source)
+    private static CSharpCompilation CreateCompilation(string source, bool reactive)
     {
         var references = GetFrameworkReferences()
             .Concat(
@@ -79,7 +306,15 @@ public sealed class SourceGeneratorTests
                 MetadataReference.CreateFromFile(typeof(LinqExtensions).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(MultipleDisposable).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(IObservableAsync<>).Assembly.Location),
-            ]);
+            ])
+            .Concat(reactive
+                ? [
+                    MetadataReference.CreateFromFile(typeof(ReactivePlcModelAttribute).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ReactiveIABPlcRx).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ReactiveLinqExtensions).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ReactiveAsyncContext).Assembly.Location),
+                ]
+                : []);
 
         return CSharpCompilation.Create(
             "GeneratedSample",
@@ -93,16 +328,31 @@ public sealed class SourceGeneratorTests
     private static IEnumerable<MetadataReference> GetFrameworkReferences()
     {
         var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
-        return string.IsNullOrWhiteSpace(trustedPlatformAssemblies)
+        var frameworkReferences = string.IsNullOrWhiteSpace(trustedPlatformAssemblies)
             ? []
             : trustedPlatformAssemblies
                 .Split(Path.PathSeparator)
                 .Where(File.Exists)
                 .Select(CreateMetadataReference);
+
+        return frameworkReferences.Concat(GetOutputAssemblyReferences());
     }
 
     /// <summary>Creates a metadata reference from an assembly path.</summary>
     /// <param name="path">The assembly path.</param>
     /// <returns>The metadata reference.</returns>
     private static MetadataReference CreateMetadataReference(string path) => MetadataReference.CreateFromFile(path);
+
+    /// <summary>Gets copied package assemblies from the test output folder.</summary>
+    /// <returns>The metadata references.</returns>
+    private static IEnumerable<MetadataReference> GetOutputAssemblyReferences() =>
+        Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll")
+            .Where(File.Exists)
+            .Select(CreateMetadataReference);
+
+    /// <summary>Stores a generator execution result.</summary>
+    /// <param name="Driver">The generator driver.</param>
+    /// <param name="OutputCompilation">The output compilation.</param>
+    /// <param name="Diagnostics">The generator diagnostics.</param>
+    private sealed record GeneratorRun(GeneratorDriver Driver, Compilation OutputCompilation, ImmutableArray<Diagnostic> Diagnostics);
 }

--- a/src/ABPlcRx.Tests/ValueObjectTests.cs
+++ b/src/ABPlcRx.Tests/ValueObjectTests.cs
@@ -13,6 +13,45 @@ namespace ABPlcRx.Tests;
 /// <summary>Tests value objects and validation helpers that do not require PLC IO.</summary>
 public sealed class ValueObjectTests
 {
+    /// <summary>Expected PLC string storage size for a short string value.</summary>
+    private const int ExpectedStringSize = 88;
+
+    /// <summary>Expected PLC storage size for the sample integer array.</summary>
+    private const int ExpectedSampleIntegerArraySize = 12;
+
+    /// <summary>Sample count value for composite values.</summary>
+    private const int CompositeCount = 7;
+
+    /// <summary>Sample code value for composite values.</summary>
+    private const short CompositeCode = 4;
+
+    /// <summary>Expected PLC storage size for the sample composite value.</summary>
+    private const int ExpectedCompositeSize = 94;
+
+    /// <summary>Sample tag value used by result tests.</summary>
+    private const int SampleTagValue = 42;
+
+    /// <summary>Seconds added to create a later timestamp.</summary>
+    private const int LaterTimestampOffsetSeconds = 2;
+
+    /// <summary>Execution time for the first result.</summary>
+    private const long FirstExecutionTime = 5;
+
+    /// <summary>Execution time for the second result.</summary>
+    private const long SecondExecutionTime = 7;
+
+    /// <summary>Expected reduced execution time.</summary>
+    private const long CombinedExecutionTime = 12;
+
+    /// <summary>Bit index used by source generation attributes.</summary>
+    private const int AttributeBit = 3;
+
+    /// <summary>Invalid bit index used by wrapper validation.</summary>
+    private const int InvalidWrapperBitIndex = 8;
+
+    /// <summary>Invalid PLC string payload length.</summary>
+    private const int InvalidStringLength = 83;
+
     /// <summary>Sample integer array used by size calculation tests.</summary>
     private static readonly int[] SampleIntegers = [1, 2, 3];
 
@@ -23,9 +62,9 @@ public sealed class ValueObjectTests
     {
         await Assert.That(GetSizeObject(null)).IsEqualTo(0);
         await Assert.That(GetSizeObject(true)).IsEqualTo(1);
-        await Assert.That(GetSizeObject("hello")).IsEqualTo(88);
-        await Assert.That(GetSizeObject(SampleIntegers)).IsEqualTo(12);
-        await Assert.That(GetSizeObject(new CompositeValue { Count = 7, Code = 4, Text = "A" })).IsEqualTo(94);
+        await Assert.That(GetSizeObject("hello")).IsEqualTo(ExpectedStringSize);
+        await Assert.That(GetSizeObject(SampleIntegers)).IsEqualTo(ExpectedSampleIntegerArraySize);
+        await Assert.That(GetSizeObject(new CompositeValue { Count = CompositeCount, Code = CompositeCode, Text = "A" })).IsEqualTo(ExpectedCompositeSize);
         await Assert.That(IsNativeType(typeof(double))).IsTrue();
         await Assert.That(IsNativeType(typeof(CompositeValue))).IsFalse();
     }
@@ -35,17 +74,17 @@ public sealed class ValueObjectTests
     [Test]
     internal async Task PlcTagResultReduceAggregatesResultsAsync()
     {
-        var tag = new StubTag("Counter", 42);
+        var tag = new StubTag("Counter", SampleTagValue);
         var timestamp = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
-        var first = CreateResult(tag, timestamp.AddSeconds(2), 5, PlcTagStatus.StatusOK);
-        var second = CreateResult(tag, timestamp, 7, PlcTagStatus.ErrBadParam);
+        var first = CreateResult(tag, timestamp.AddSeconds(LaterTimestampOffsetSeconds), FirstExecutionTime, PlcTagStatus.StatusOK);
+        var second = CreateResult(tag, timestamp, SecondExecutionTime, PlcTagStatus.ErrBadParam);
 
         var reduced = PlcTagResult.Reduce([first, second]);
         var text = second.ToString();
 
         await Assert.That(reduced.Tag).IsEqualTo(tag);
         await Assert.That(reduced.Timestamp).IsEqualTo(timestamp);
-        await Assert.That(reduced.ExecutionTime).IsEqualTo(12);
+        await Assert.That(reduced.ExecutionTime).IsEqualTo(CombinedExecutionTime);
         await Assert.That(reduced.StatusCode).IsEqualTo(PlcTagStatus.ErrBadParam);
         await Assert.That(text).Contains("Counter");
         await Assert.That(text).Contains("42");
@@ -58,7 +97,7 @@ public sealed class ValueObjectTests
     internal async Task PlcTagExceptionConstructorsPreserveDetailsAsync()
     {
         var inner = new InvalidOperationException("inner");
-        var result = CreateResult(new StubTag("Counter", 42), DateTime.UtcNow, 1, PlcTagStatus.ErrBadParam);
+        var result = CreateResult(new StubTag("Counter", SampleTagValue), DateTime.UtcNow, 1, PlcTagStatus.ErrBadParam);
 
         var defaultException = new PlcTagException();
         var messageException = new PlcTagException("custom");
@@ -80,7 +119,7 @@ public sealed class ValueObjectTests
         {
             Variable = "Counter",
             Group = "Fast",
-            Bit = 3,
+            Bit = AttributeBit,
             RegisterTag = false,
         };
         var classAttribute = new PlcTagAttribute(typeof(int), "Counter", "N7:0");
@@ -91,7 +130,7 @@ public sealed class ValueObjectTests
         await Assert.That(propertyAttribute.PropertyName).IsNull();
         await Assert.That(propertyAttribute.Variable).IsEqualTo("Counter");
         await Assert.That(propertyAttribute.Group).IsEqualTo("Fast");
-        await Assert.That(propertyAttribute.Bit).IsEqualTo(3);
+        await Assert.That(propertyAttribute.Bit).IsEqualTo(AttributeBit);
         await Assert.That(propertyAttribute.RegisterTag).IsFalse();
         await Assert.That(classAttribute.ValueType).IsEqualTo(typeof(int));
         await Assert.That(classAttribute.PropertyName).IsEqualTo("Counter");
@@ -106,10 +145,10 @@ public sealed class ValueObjectTests
     {
         var wrapper = CreateWrapper(new StubTag("Counter", 0) { Size = 1, TypeValue = typeof(int) });
 
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => wrapper.SetBit(8, true));
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => wrapper.SetBit(InvalidWrapperBitIndex, true));
         _ = Assert.Throws<ArgumentNullException>(() => wrapper.SetBits(null!));
         _ = Assert.Throws<ArgumentOutOfRangeException>(() => wrapper.SetString(string.Empty));
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => wrapper.SetString(new string('x', 83)));
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => wrapper.SetString(new string('x', InvalidStringLength)));
         await Assert.That(wrapper.GetType(null!)).IsNull();
         await Assert.That(InvokeWrapperGet(wrapper, null)).IsNull();
         await Assert.That(() => InvokeWrapperSet(wrapper, null)).ThrowsNothing();
@@ -139,18 +178,7 @@ public sealed class ValueObjectTests
     /// <summary>Creates a PLC tag wrapper through its internal constructor.</summary>
     /// <param name="tag">The wrapped tag.</param>
     /// <returns>The wrapper instance.</returns>
-    private static PlcTagWrapper CreateWrapper(IPlcTag tag)
-    {
-        var result = Activator.CreateInstance(
-            typeof(PlcTagWrapper),
-            BindingFlags.Instance | BindingFlags.NonPublic,
-            null,
-            [tag],
-            null);
-        return result is PlcTagWrapper wrapper
-            ? wrapper
-            : throw new InvalidOperationException("The PLC tag wrapper constructor returned an unexpected value.");
-    }
+    private static PlcTagWrapper CreateWrapper(IPlcTag tag) => new(tag);
 
     /// <summary>Invokes the internal data length size helper.</summary>
     /// <param name="value">The value to measure.</param>

--- a/src/ABPlcRx.slnx
+++ b/src/ABPlcRx.slnx
@@ -9,6 +9,7 @@
     <File Path="../.github/dependabot.yml" />
     <File Path="../.gitignore" />
     <File Path="../Directory.Build.props" />
+    <File Path="../global.json" />
     <File Path="../LICENSE" />
     <File Path="../README.md" />
     <File Path="../version.json" />

--- a/src/ABPlcRx.slnx
+++ b/src/ABPlcRx.slnx
@@ -16,6 +16,7 @@
   <Project Path="../build/_build.csproj">
     <Build Solution="*|Any CPU" Project="false" />
   </Project>
+  <Project Path="ABPlcRx.Reactive/ABPlcRx.Reactive.csproj" />
   <Project Path="ABPlcRx.SourceGenerators/ABPlcRx.SourceGenerators.csproj" />
   <Project Path="ABPlcRx.TestApp/ABPlcRx.TestApp.csproj" />
   <Project Path="ABPlcRx.Tests/ABPlcRx.Tests.csproj" />

--- a/src/ABPlcRx/ABPlcRx.cs
+++ b/src/ABPlcRx/ABPlcRx.cs
@@ -2,19 +2,10 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.Primitives.Disposables;
 #if REACTIVE_SHIM
-using ReactiveUI.Primitives.Extensions.Reactive;
-using ReactiveUI.Primitives.Reactive;
 using SignalFactory = ReactiveUI.Primitives.Reactive.Signals.Signal;
 #else
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Extensions;
 using SignalFactory = ReactiveUI.Primitives.Signals.Signal;
-#endif
-#if NET8_0_OR_GREATER
-using ReactiveUI.Primitives.Async;
 #endif
 
 #if REACTIVELIST_REACTIVE
@@ -96,12 +87,10 @@ public class ABPlcRx : IABPlcRx
     /// <value>The data read.</value>
     public IObservable<IPlcTag?> ObserveAll => MergeTagChanges(_plc.Tags).Select(c => c.Tag);
 
-#if NET8_0_OR_GREATER
     /// <summary>Gets the data read as an async-native observable.</summary>
     /// <value>The async data read stream.</value>
     public IObservableAsync<IPlcTag?> ObserveAllAsyncObservable =>
         ObservableAsyncBridgeExtensions.ToAsyncObservable(ObserveAll);
-#endif
 
     /// <summary>Gets or sets a value indicating whether [scan enabled].</summary>
     /// <value>

--- a/src/ABPlcRx/ABPlcRx.cs
+++ b/src/ABPlcRx/ABPlcRx.cs
@@ -2,20 +2,42 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI.Primitives.Disposables;
+#if REACTIVE_SHIM
+using ReactiveUI.Primitives.Extensions.Reactive;
+using ReactiveUI.Primitives.Reactive;
+using SignalFactory = ReactiveUI.Primitives.Reactive.Signals.Signal;
+#else
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Primitives.Extensions;
-using ReactiveUI.Primitives.Signals;
+using SignalFactory = ReactiveUI.Primitives.Signals.Signal;
+#endif
 #if NET8_0_OR_GREATER
 using ReactiveUI.Primitives.Async;
 #endif
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Reactive Allen Bradley PLC facade.</summary>
 public class ABPlcRx : IABPlcRx
 {
+    /// <summary>Number of bits in a byte or signed byte.</summary>
+    private const int ByteBitWidth = 8;
+
+    /// <summary>Number of bits in a 16-bit integer.</summary>
+    private const int Int16BitWidth = 16;
+
+    /// <summary>Number of bits in a 32-bit integer.</summary>
+    private const int Int32BitWidth = 32;
+
+    /// <summary>Number of bits in a 64-bit integer.</summary>
+    private const int Int64BitWidth = 64;
+
     /// <summary>Tracks subscriptions and owned disposable resources.</summary>
     private readonly MultipleDisposable _disposables = [];
 
@@ -178,7 +200,7 @@ public class ABPlcRx : IABPlcRx
     public IObservable<IReadOnlyDictionary<string, object?>> ObserveMany(params string[] variables)
     {
         return variables is null || variables.Length == 0
-            ? Signal.Return((IReadOnlyDictionary<string, object?>)new Dictionary<string, object?>())
+            ? SignalFactory.Return((IReadOnlyDictionary<string, object?>)new Dictionary<string, object?>())
             : _plc.TagsAdded
             .Select(_ => RxVoid.Default)
             .StartWith(RxVoid.Default)
@@ -200,12 +222,12 @@ public class ABPlcRx : IABPlcRx
     /// <param name="groupName">The group name to observe.</param>
     /// <returns>Observable sequence of tags in the group that have changed.</returns>
     public IObservable<IPlcTag> ObserveGroup(string groupName) =>
-        Signal.Lazy(() =>
+        SignalFactory.Lazy(() =>
         {
             var group = _plc.GetTagGroup(groupName);
 
             // existing tags
-            var current = Signal.Merge(group.Tags.Select(t => t.Changed.Select(_ => t)));
+            var current = SignalFactory.Merge(group.Tags.Select(t => t.Changed.Select(_ => t)));
 
             // future tags that end up in the same group
             var future = _plc.TagsAdded
@@ -288,8 +310,8 @@ public class ABPlcRx : IABPlcRx
     /// <param name="scheduler">Optional scheduler for the ping cadence.</param>
     /// <returns>Observable sequence of ping result states, deduplicated.</returns>
     public IObservable<bool> ObservePing(TimeSpan interval, bool echo = false, ISequencer? scheduler = null)
-        => Signal.Timer(TimeSpan.Zero, interval, scheduler ?? TaskPoolSequencer.Default)
-                      .SelectMany(_ => Signal.FromAsync(ct => _plc.PingAsync(echo, ct)))
+        => SignalFactory.Timer(TimeSpan.Zero, interval, scheduler ?? TaskPoolSequencer.Default)
+                      .SelectMany(_ => SignalFactory.FromAsync(ct => _plc.PingAsync(echo, ct)))
                       .DistinctUntilChanged()
                       .Publish()
                       .RefCount();
@@ -435,10 +457,10 @@ public class ABPlcRx : IABPlcRx
     {
         var bitWidth = Type.GetTypeCode(tagType) switch
         {
-            TypeCode.Byte or TypeCode.SByte => 8,
-            TypeCode.UInt16 or TypeCode.Int16 => 16,
-            TypeCode.UInt32 or TypeCode.Int32 => 32,
-            TypeCode.UInt64 or TypeCode.Int64 => 64,
+            TypeCode.Byte or TypeCode.SByte => ByteBitWidth,
+            TypeCode.UInt16 or TypeCode.Int16 => Int16BitWidth,
+            TypeCode.UInt32 or TypeCode.Int32 => Int32BitWidth,
+            TypeCode.UInt64 or TypeCode.Int64 => Int64BitWidth,
             _ => throw new ArgumentException("Bit operations require an integral PLC tag type.", nameof(tagType)),
         };
 
@@ -495,7 +517,7 @@ public class ABPlcRx : IABPlcRx
     private static IObservable<PlcTagResult> MergeTagChanges(IEnumerable<IPlcTag> tags)
     {
         var streams = tags.Select(tag => tag.Changed).ToArray();
-        return streams.Length == 0 ? Signal.Silent<PlcTagResult>() : Signal.Merge(streams);
+        return streams.Length == 0 ? SignalFactory.Silent<PlcTagResult>() : SignalFactory.Merge(streams);
     }
 
     /// <summary>Creates a latest-value snapshot for observed tags.</summary>
@@ -508,7 +530,7 @@ public class ABPlcRx : IABPlcRx
     /// <param name="variables">The variables to observe.</param>
     /// <returns>An observable dictionary of current values.</returns>
     private IObservable<IReadOnlyDictionary<string, object?>> ObserveManySnapshot(string[] variables) =>
-        Signal.Create<IReadOnlyDictionary<string, object?>>(observer =>
+        SignalFactory.Create<IReadOnlyDictionary<string, object?>>(observer =>
         {
             var tags = variables
                 .Select(variable => (Variable: variable, Tag: _plc.GetPlcTag(variable)))

--- a/src/ABPlcRx/ABPlcRx.csproj
+++ b/src/ABPlcRx/ABPlcRx.csproj
@@ -14,6 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="ReactiveUI.Primitives.Signals" />
+    <Using Include="ReactiveUI.Primitives" />
+    <Using Include="ReactiveUI.Primitives.Async" />
+    <Using Include="ReactiveUI.Primitives.Disposables" />
+    <Using Include="ReactiveUI.Primitives.Extensions" />
+    <Using Include="ReactiveUI.Primitives.Concurrency" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>ABPlcRx.Tests</_Parameter1>
     </AssemblyAttribute>

--- a/src/ABPlcRx/Core/ABPlc.cs
+++ b/src/ABPlcRx/Core/ABPlc.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.ObjectModel;
 using System.Net.NetworkInformation;
-using ReactiveUI.Primitives.Signals;
 
 #if REACTIVELIST_REACTIVE
 namespace ABPlcRx.Reactive;

--- a/src/ABPlcRx/Core/ABPlc.cs
+++ b/src/ABPlcRx/Core/ABPlc.cs
@@ -6,7 +6,11 @@ using System.Collections.ObjectModel;
 using System.Net.NetworkInformation;
 using ReactiveUI.Primitives.Signals;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Allen Bradley Plc.</summary>
 internal sealed class ABPlc : IDisposable
@@ -39,7 +43,7 @@ internal sealed class ABPlc : IDisposable
     /// <param name="address">The IP address of the PLC.</param>
     /// <param name="plcType">Type of the PLC.</param>
     public ABPlc(string address, PlcType plcType)
-        : this(address, plcType, null)
+        : this(address, plcType, null, LibPlcTagNative.Instance)
     {
     }
 
@@ -51,15 +55,28 @@ internal sealed class ABPlc : IDisposable
     /// <para></para>Slot number where cpu is installed: 0,1..</param>
     /// <exception cref="System.ArgumentException">PortType and Slot must be specified for ControlLogix / CompactLogix processors.</exception>
     public ABPlc(string address, PlcType plcType, string? slot)
+        : this(address, plcType, slot, LibPlcTagNative.Instance)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ABPlc" /> class.</summary>
+    /// <param name="address">The IP address of the PLC.</param>
+    /// <param name="plcType">Type of the PLC.</param>
+    /// <param name="slot">The PLC slot path.</param>
+    /// <param name="native">The native tag adapter.</param>
+    internal ABPlc(string address, PlcType plcType, string? slot, IPlcTagNative native)
     {
         if (plcType == PlcType.LGX && string.IsNullOrEmpty(slot))
         {
             throw new ArgumentException("plcType and slot must be specified for ControlLogix / CompactLogix processors");
         }
 
+        ArgumentExceptionHelper.ThrowIfNull(native, nameof(native));
+
         IPAddress = address;
         Slot = slot;
         PlcType = plcType;
+        Native = native;
     }
 
     /// <summary>Finalizes an instance of the <see cref="ABPlc"/> class.</summary>
@@ -129,6 +146,9 @@ internal sealed class ABPlc : IDisposable
 
     /// <summary>Gets or sets communication timeout millisec.</summary>
     public int Timeout { get; set; } = 5000;
+
+    /// <summary>Gets the native tag adapter.</summary>
+    internal IPlcTagNative Native { get; }
 
     /// <summary>Creates new TagList.</summary>
     /// <param name="name">The name.</param>

--- a/src/ABPlcRx/Core/ArgumentExceptionHelper.cs
+++ b/src/ABPlcRx/Core/ArgumentExceptionHelper.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Cross-target argument guard helpers.</summary>
 internal static class ArgumentExceptionHelper

--- a/src/ABPlcRx/Core/DataLength.cs
+++ b/src/ABPlcRx/Core/DataLength.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Tag size definition.</summary>
 internal static class DataLength

--- a/src/ABPlcRx/Core/IPlcTag.cs
+++ b/src/ABPlcRx/Core/IPlcTag.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Interface Tag.</summary>
 public interface IPlcTag : IDisposable

--- a/src/ABPlcRx/Core/IPlcTagNative.cs
+++ b/src/ABPlcRx/Core/IPlcTagNative.cs
@@ -1,0 +1,181 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
+namespace ABPlcRx;
+#endif
+
+/// <summary>Abstraction over libplctag native calls.</summary>
+internal interface IPlcTagNative
+{
+    /// <summary>Creates a native PLC tag.</summary>
+    /// <param name="url">The native connection URL.</param>
+    /// <param name="timeout">The operation timeout.</param>
+    /// <returns>The native handle.</returns>
+    int Create(string url, int timeout);
+
+    /// <summary>Destroys a native PLC tag.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <returns>The native status code.</returns>
+    int Destroy(int handle);
+
+    /// <summary>Aborts native PLC tag IO.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <returns>The native status code.</returns>
+    int Abort(int handle);
+
+    /// <summary>Gets the native PLC tag size.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <returns>The tag size.</returns>
+    int GetSize(int handle);
+
+    /// <summary>Gets the native PLC tag status.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <returns>The native status code.</returns>
+    int GetStatus(int handle);
+
+    /// <summary>Locks a native PLC tag.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <returns>The native status code.</returns>
+    int Lock(int handle);
+
+    /// <summary>Reads a native PLC tag.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="timeout">The operation timeout.</param>
+    /// <returns>The native status code.</returns>
+    int Read(int handle, int timeout);
+
+    /// <summary>Unlocks a native PLC tag.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <returns>The native status code.</returns>
+    int Unlock(int handle);
+
+    /// <summary>Writes a native PLC tag.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="timeout">The operation timeout.</param>
+    /// <returns>The native status code.</returns>
+    int Write(int handle, int timeout);
+
+    /// <summary>Gets a 32-bit floating-point value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    float GetFloat32(int handle, int offset);
+
+    /// <summary>Gets a 64-bit floating-point value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    double GetFloat64(int handle, int offset);
+
+    /// <summary>Gets a signed 16-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    short GetInt16(int handle, int offset);
+
+    /// <summary>Gets a signed 32-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    int GetInt32(int handle, int offset);
+
+    /// <summary>Gets a signed 64-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    long GetInt64(int handle, int offset);
+
+    /// <summary>Gets a signed 8-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    sbyte GetInt8(int handle, int offset);
+
+    /// <summary>Gets an unsigned 16-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    ushort GetUInt16(int handle, int offset);
+
+    /// <summary>Gets an unsigned 32-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    uint GetUInt32(int handle, int offset);
+
+    /// <summary>Gets an unsigned 64-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    ulong GetUInt64(int handle, int offset);
+
+    /// <summary>Gets an unsigned 8-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The value.</returns>
+    byte GetUInt8(int handle, int offset);
+
+    /// <summary>Sets a 32-bit floating-point value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetFloat32(int handle, int offset, float value);
+
+    /// <summary>Sets a 64-bit floating-point value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetFloat64(int handle, int offset, double value);
+
+    /// <summary>Sets a signed 16-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetInt16(int handle, int offset, short value);
+
+    /// <summary>Sets a signed 32-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetInt32(int handle, int offset, int value);
+
+    /// <summary>Sets a signed 64-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetInt64(int handle, int offset, long value);
+
+    /// <summary>Sets a signed 8-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetInt8(int handle, int offset, sbyte value);
+
+    /// <summary>Sets an unsigned 16-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetUInt16(int handle, int offset, ushort value);
+
+    /// <summary>Sets an unsigned 32-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetUInt32(int handle, int offset, uint value);
+
+    /// <summary>Sets an unsigned 64-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetUInt64(int handle, int offset, ulong value);
+
+    /// <summary>Sets an unsigned 8-bit value.</summary>
+    /// <param name="handle">The native handle.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <param name="value">The value.</param>
+    void SetUInt8(int handle, int offset, byte value);
+}

--- a/src/ABPlcRx/Core/IPlcTag{TType}.cs
+++ b/src/ABPlcRx/Core/IPlcTag{TType}.cs
@@ -2,11 +2,15 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Interface Tag.</summary>
 /// <typeparam name="TType">The type of the type.</typeparam>
-/// <seealso cref="global::ABPlcRx.IPlcTag" />
+/// <seealso cref="IPlcTag" />
 public interface IPlcTag<TType> : IPlcTag
 {
     /// <summary>Gets or sets the value.</summary>

--- a/src/ABPlcRx/Core/LibPlcTagNative.cs
+++ b/src/ABPlcRx/Core/LibPlcTagNative.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
+// Chris Pulman licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using libplctag.NativeImport;
+
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
+namespace ABPlcRx;
+#endif
+
+/// <summary>libplctag-backed native PLC tag adapter.</summary>
+internal sealed class LibPlcTagNative : IPlcTagNative
+{
+    /// <summary>Initializes a new instance of the <see cref="LibPlcTagNative"/> class.</summary>
+    private LibPlcTagNative()
+    {
+    }
+
+    /// <summary>Gets the shared native adapter instance.</summary>
+    public static IPlcTagNative Instance { get; } = new LibPlcTagNative();
+
+    /// <inheritdoc/>
+    public int Create(string url, int timeout) => plctag.plc_tag_create(url, timeout);
+
+    /// <inheritdoc/>
+    public int Destroy(int handle) => plctag.plc_tag_destroy(handle);
+
+    /// <inheritdoc/>
+    public int Abort(int handle) => plctag.plc_tag_abort(handle);
+
+    /// <inheritdoc/>
+    public int GetSize(int handle) => plctag.plc_tag_get_size(handle);
+
+    /// <inheritdoc/>
+    public int GetStatus(int handle) => plctag.plc_tag_status(handle);
+
+    /// <inheritdoc/>
+    public int Lock(int handle) => plctag.plc_tag_lock(handle);
+
+    /// <inheritdoc/>
+    public int Read(int handle, int timeout) => plctag.plc_tag_read(handle, timeout);
+
+    /// <inheritdoc/>
+    public int Unlock(int handle) => plctag.plc_tag_unlock(handle);
+
+    /// <inheritdoc/>
+    public int Write(int handle, int timeout) => plctag.plc_tag_write(handle, timeout);
+
+    /// <inheritdoc/>
+    public float GetFloat32(int handle, int offset) => plctag.plc_tag_get_float32(handle, offset);
+
+    /// <inheritdoc/>
+    public double GetFloat64(int handle, int offset) => plctag.plc_tag_get_float64(handle, offset);
+
+    /// <inheritdoc/>
+    public short GetInt16(int handle, int offset) => plctag.plc_tag_get_int16(handle, offset);
+
+    /// <inheritdoc/>
+    public int GetInt32(int handle, int offset) => plctag.plc_tag_get_int32(handle, offset);
+
+    /// <inheritdoc/>
+    public long GetInt64(int handle, int offset) => plctag.plc_tag_get_int64(handle, offset);
+
+    /// <inheritdoc/>
+    public sbyte GetInt8(int handle, int offset) => plctag.plc_tag_get_int8(handle, offset);
+
+    /// <inheritdoc/>
+    public ushort GetUInt16(int handle, int offset) => plctag.plc_tag_get_uint16(handle, offset);
+
+    /// <inheritdoc/>
+    public uint GetUInt32(int handle, int offset) => plctag.plc_tag_get_uint32(handle, offset);
+
+    /// <inheritdoc/>
+    public ulong GetUInt64(int handle, int offset) => plctag.plc_tag_get_uint64(handle, offset);
+
+    /// <inheritdoc/>
+    public byte GetUInt8(int handle, int offset) => plctag.plc_tag_get_uint8(handle, offset);
+
+    /// <inheritdoc/>
+    public void SetFloat32(int handle, int offset, float value) => plctag.plc_tag_set_float32(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetFloat64(int handle, int offset, double value) => plctag.plc_tag_set_float64(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetInt16(int handle, int offset, short value) => plctag.plc_tag_set_int16(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetInt32(int handle, int offset, int value) => plctag.plc_tag_set_int32(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetInt64(int handle, int offset, long value) => plctag.plc_tag_set_int64(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetInt8(int handle, int offset, sbyte value) => plctag.plc_tag_set_int8(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetUInt16(int handle, int offset, ushort value) => plctag.plc_tag_set_uint16(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetUInt32(int handle, int offset, uint value) => plctag.plc_tag_set_uint32(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetUInt64(int handle, int offset, ulong value) => plctag.plc_tag_set_uint64(handle, offset, value);
+
+    /// <inheritdoc/>
+    public void SetUInt8(int handle, int offset, byte value) => plctag.plc_tag_set_uint8(handle, offset, value);
+}

--- a/src/ABPlcRx/Core/PlcTag.cs
+++ b/src/ABPlcRx/Core/PlcTag.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
-using ReactiveUI.Primitives.Signals;
 
 #if REACTIVELIST_REACTIVE
 namespace ABPlcRx.Reactive;

--- a/src/ABPlcRx/Core/PlcTag.cs
+++ b/src/ABPlcRx/Core/PlcTag.cs
@@ -4,9 +4,12 @@
 
 using System.Diagnostics;
 using ReactiveUI.Primitives.Signals;
-using libplctag.NativeImport;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Tag base definition.</summary>
 /// <typeparam name="TType">The type of the type.</typeparam>
@@ -15,6 +18,9 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
 {
     /// <summary>Publishes tag read changes.</summary>
     private readonly Signal<PlcTagResult> _changedSubject = new();
+
+    /// <summary>Native PLC tag adapter.</summary>
+    private readonly IPlcTagNative _native;
 
     /// <summary>Tracks disposal state.</summary>
     private bool _disposed;
@@ -40,7 +46,8 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
         TagName = tagName;
         Size = size;
         Length = length;
-        ValueManager = new(this);
+        _native = plc.Native;
+        ValueManager = new(this, _native);
         TypeValue = typeof(TType);
 
         var url = $"protocol=ab_eip&gateway={plc.IPAddress}";
@@ -56,7 +63,7 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
         }
 
         // create reference
-        Handle = plctag.plc_tag_create(url, plc.Timeout);
+        Handle = _native.Create(url, plc.Timeout);
 
         Value = TagHelper.CreateObject<TType>(Length);
     }
@@ -145,7 +152,7 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
 
     /// <summary>Abort any outstanding IO to the PLC. <see cref="PlcTagStatus"/>.</summary>
     /// <returns>A Value.</returns>
-    public int Abort() => plctag.plc_tag_abort(Handle);
+    public int Abort() => _native.Abort(Handle);
 
     /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
     public void Dispose()
@@ -156,15 +163,15 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
 
     /// <summary>Get size tag read from PLC.</summary>
     /// <returns>A Value.</returns>
-    public int GetSize() => plctag.plc_tag_get_size(Handle);
+    public int GetSize() => _native.GetSize(Handle);
 
     /// <summary>Get status operation. <see cref="PlcTagStatus"/>.</summary>
     /// <returns>A Value.</returns>
-    public int GetStatus() => plctag.plc_tag_status(Handle);
+    public int GetStatus() => _native.GetStatus(Handle);
 
     /// <summary>Lock for multitrading. <see cref="PlcTagStatus"/>.</summary>
     /// <returns>A Value.</returns>
-    public int Lock() => plctag.plc_tag_lock(Handle);
+    public int Lock() => _native.Lock(Handle);
 
     /// <summary>Performs read of Tag.</summary>
     /// <returns>A Value.</returns>
@@ -172,7 +179,7 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
     {
         var timestamp = DateTime.UtcNow;
         var watch = Stopwatch.StartNew();
-        var statusCode = plctag.plc_tag_read(Handle, ABPlc.Timeout);
+        var statusCode = _native.Read(Handle, ABPlc.Timeout);
 
         watch.Stop();
         IsRead = true;
@@ -195,7 +202,7 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
 
     /// <summary>Unlock for multitrading <see cref="PlcTagStatus"/>.</summary>
     /// <returns>A Value.</returns>
-    public int Unlock() => plctag.plc_tag_unlock(Handle);
+    public int Unlock() => _native.Unlock(Handle);
 
     /// <summary>Performs write of Tag.</summary>
     /// <returns>A Value.</returns>
@@ -210,7 +217,7 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
 
         var timestamp = DateTime.UtcNow;
         var watch = Stopwatch.StartNew();
-        var statusCode = plctag.plc_tag_write(Handle, ABPlc.Timeout);
+        var statusCode = _native.Write(Handle, ABPlc.Timeout);
         watch.Stop();
         IsWrite = true;
 
@@ -240,7 +247,7 @@ internal sealed class PlcTag<TType> : IPlcTag<TType>
         }
 
         // Always destroy native handle
-        _ = plctag.plc_tag_destroy(Handle);
+        _ = _native.Destroy(Handle);
         _disposed = true;
     }
 }

--- a/src/ABPlcRx/Core/PlcTagCollection.cs
+++ b/src/ABPlcRx/Core/PlcTagCollection.cs
@@ -4,13 +4,10 @@
 
 using System.Collections;
 #if REACTIVE_SHIM
-using ReactiveUI.Primitives.Reactive;
 using SignalFactory = ReactiveUI.Primitives.Reactive.Signals.Signal;
 #else
-using ReactiveUI.Primitives;
 using SignalFactory = ReactiveUI.Primitives.Signals.Signal;
 #endif
-using ReactiveUI.Primitives.Signals;
 
 #if REACTIVELIST_REACTIVE
 namespace ABPlcRx.Reactive;

--- a/src/ABPlcRx/Core/PlcTagCollection.cs
+++ b/src/ABPlcRx/Core/PlcTagCollection.cs
@@ -3,10 +3,20 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections;
+#if REACTIVE_SHIM
+using ReactiveUI.Primitives.Reactive;
+using SignalFactory = ReactiveUI.Primitives.Reactive.Signals.Signal;
+#else
 using ReactiveUI.Primitives;
+using SignalFactory = ReactiveUI.Primitives.Signals.Signal;
+#endif
 using ReactiveUI.Primitives.Signals;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Plc Tag Collection.</summary>
 internal sealed class PlcTagCollection : IDisposable
@@ -35,7 +45,7 @@ internal sealed class PlcTagCollection : IDisposable
     internal PlcTagCollection(ABPlc plc, TimeSpan scanInterval)
     {
         Plc = plc;
-        _scanDisposable = Signal.Timer(TimeSpan.Zero, scanInterval).Subscribe(_ =>
+        _scanDisposable = SignalFactory.Timer(TimeSpan.Zero, scanInterval).Subscribe(_ =>
         {
             if (!ScanEnabled || _disposed)
             {
@@ -74,7 +84,16 @@ internal sealed class PlcTagCollection : IDisposable
 
     /// <summary>Gets tags.</summary>
     /// <returns>A Value.</returns>
-    public IReadOnlyList<IPlcTag> Tags => _tags.AsReadOnly();
+    public IReadOnlyList<IPlcTag> Tags
+    {
+        get
+        {
+            lock (_lockScan)
+            {
+                return Array.AsReadOnly(_tags.ToArray());
+            }
+        }
+    }
 
     /// <summary>Gets controller.</summary>
     /// <value>
@@ -83,7 +102,13 @@ internal sealed class PlcTagCollection : IDisposable
     internal ABPlc Plc { get; }
 
     /// <summary>Clears all Tags from the group.</summary>
-    public void ClearTags() => _tags.Clear();
+    public void ClearTags()
+    {
+        lock (_lockScan)
+        {
+            _tags.Clear();
+        }
+    }
 
     /// <summary>Create Tag array.</summary>
     /// <typeparam name="TCustomType">Type to create.</typeparam>
@@ -141,7 +166,11 @@ internal sealed class PlcTagCollection : IDisposable
     public IPlcTag<TCustomType> CreateTagType<TCustomType>(string variable, string tagName, int size, int length = 1)
     {
         var tag = new PlcTag<TCustomType>(Plc, variable, tagName, size, length);
-        _tags.Add(tag);
+        lock (_lockScan)
+        {
+            _tags.Add(tag);
+        }
+
         return tag;
     }
 
@@ -154,7 +183,7 @@ internal sealed class PlcTagCollection : IDisposable
 
     /// <summary>Performs read of Group of Tags.</summary>
     /// <returns>A Value.</returns>
-    public IEnumerable<PlcTagResult> Read() => [.. Tags.Select(a => a.Read())];
+    public IEnumerable<PlcTagResult> Read() => [.. SnapshotTags().Select(a => a.Read())];
 
     /// <summary>Remove tag.</summary>
     /// <param name="tag">The tag.</param>
@@ -163,18 +192,26 @@ internal sealed class PlcTagCollection : IDisposable
     {
         ArgumentExceptionHelper.ThrowIfNull(tag, nameof(tag));
 
-        if (!Tags.Contains(tag))
+        var removed = false;
+        lock (_lockScan)
+        {
+            if (_tags.Contains(tag))
+            {
+                removed = _tags.Remove(tag);
+            }
+        }
+
+        if (!removed)
         {
             throw new ArgumentException("Tag not exists in this collection!");
         }
 
-        _ = _tags.Remove(tag);
         CheckDisposeTag(tag);
     }
 
     /// <summary>Performs write of Group of Tags.</summary>
     /// <returns>A Value.</returns>
-    public IEnumerable<PlcTagResult> Write() => Tags.Select(a => a.Write());
+    public IEnumerable<PlcTagResult> Write() => SnapshotTags().Select(a => a.Write());
 
     /// <summary>Releases unmanaged and - optionally - managed resources.</summary>
     /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
@@ -198,7 +235,7 @@ internal sealed class PlcTagCollection : IDisposable
         lock (_lockScan)
         {
             _readResultSubject.Dispose();
-            foreach (var tag in _tags.ToArray())
+            foreach (var tag in SnapshotTags())
             {
                 _ = _tags.Remove(tag);
                 CheckDisposeTag(tag);
@@ -217,5 +254,15 @@ internal sealed class PlcTagCollection : IDisposable
         }
 
         tag.Dispose();
+    }
+
+    /// <summary>Creates a stable tag snapshot.</summary>
+    /// <returns>The tag snapshot.</returns>
+    private IPlcTag[] SnapshotTags()
+    {
+        lock (_lockScan)
+        {
+            return [.. _tags];
+        }
     }
 }

--- a/src/ABPlcRx/Core/PlcTagException.cs
+++ b/src/ABPlcRx/Core/PlcTagException.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Plc Tag Exception.</summary>
 [Serializable]

--- a/src/ABPlcRx/Core/PlcTagResult.cs
+++ b/src/ABPlcRx/Core/PlcTagResult.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Result returned by PLC tag operations.</summary>
 [Serializable]

--- a/src/ABPlcRx/Core/PlcTagStatus.cs
+++ b/src/ABPlcRx/Core/PlcTagStatus.cs
@@ -4,7 +4,11 @@
 
 using libplctag.NativeImport;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Status code operation.</summary>
 public static class PlcTagStatus

--- a/src/ABPlcRx/Core/PlcTagWrapper.cs
+++ b/src/ABPlcRx/Core/PlcTagWrapper.cs
@@ -4,13 +4,19 @@
 
 using System.Collections;
 using System.Text;
-using libplctag.NativeImport;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Plc Tag Wrapper.</summary>
 public class PlcTagWrapper
 {
+    /// <summary>Number of bits in a byte.</summary>
+    private const byte BitsPerByte = 8;
+
     /// <summary>Byte offset of string payload after the length header.</summary>
     private const byte ByteHeaderLengthString = 4;
 
@@ -20,9 +26,17 @@ public class PlcTagWrapper
     /// <summary>The wrapped PLC tag.</summary>
     private readonly IPlcTag _tag;
 
+    /// <summary>Native PLC tag adapter.</summary>
+    private readonly IPlcTagNative _native;
+
     /// <summary>Initializes a new instance of the <see cref="PlcTagWrapper"/> class.</summary>
     /// <param name="tag">The wrapped tag.</param>
-    internal PlcTagWrapper(IPlcTag tag) => _tag = tag;
+    /// <param name="native">The native tag adapter.</param>
+    internal PlcTagWrapper(IPlcTag tag, IPlcTagNative? native = null)
+    {
+        _tag = tag;
+        _native = native ?? LibPlcTagNative.Instance;
+    }
 
     /// <summary>Get bit from index.</summary>
     /// <param name="index">The index.</param>
@@ -49,32 +63,32 @@ public class PlcTagWrapper
     /// <summary>Get local value Float32.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public float GetFloat32(int offset = 0) => plctag.plc_tag_get_float32(_tag.Handle, offset);
+    public float GetFloat32(int offset = 0) => _native.GetFloat32(_tag.Handle, offset);
 
     /// <summary>Get local value Float.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public double GetFloat64(int offset = 0) => plctag.plc_tag_get_float64(_tag.Handle, offset);
+    public double GetFloat64(int offset = 0) => _native.GetFloat64(_tag.Handle, offset);
 
     /// <summary>Get local value Int16.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public short GetInt16(int offset = 0) => plctag.plc_tag_get_int16(_tag.Handle, offset);
+    public short GetInt16(int offset = 0) => _native.GetInt16(_tag.Handle, offset);
 
     /// <summary>Get local value Int32.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public int GetInt32(int offset = 0) => plctag.plc_tag_get_int32(_tag.Handle, offset);
+    public int GetInt32(int offset = 0) => _native.GetInt32(_tag.Handle, offset);
 
     /// <summary>Get local value Int64.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public long GetInt64(int offset = 0) => plctag.plc_tag_get_int64(_tag.Handle, offset);
+    public long GetInt64(int offset = 0) => _native.GetInt64(_tag.Handle, offset);
 
     /// <summary>Get local value Int8.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public sbyte GetInt8(int offset = 0) => plctag.plc_tag_get_int8(_tag.Handle, offset);
+    public sbyte GetInt8(int offset = 0) => _native.GetInt8(_tag.Handle, offset);
 
     /// <summary>Get local value String.</summary>
     /// <param name="offset">The offset.</param>
@@ -119,22 +133,22 @@ public class PlcTagWrapper
     /// <summary>Get local value UInt16.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public ushort GetUInt16(int offset = 0) => plctag.plc_tag_get_uint16(_tag.Handle, offset);
+    public ushort GetUInt16(int offset = 0) => _native.GetUInt16(_tag.Handle, offset);
 
     /// <summary>Get local value UInt32.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public uint GetUInt32(int offset = 0) => plctag.plc_tag_get_uint32(_tag.Handle, offset);
+    public uint GetUInt32(int offset = 0) => _native.GetUInt32(_tag.Handle, offset);
 
     /// <summary>Get local value UInt64.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public ulong GetUInt64(int offset = 0) => plctag.plc_tag_get_uint64(_tag.Handle, offset);
+    public ulong GetUInt64(int offset = 0) => _native.GetUInt64(_tag.Handle, offset);
 
     /// <summary>Get local value UInt8.</summary>
     /// <param name="offset">The offset.</param>
     /// <returns>A Value.</returns>
-    public byte GetUInt8(int offset = 0) => plctag.plc_tag_get_uint8(_tag.Handle, offset);
+    public byte GetUInt8(int offset = 0) => _native.GetUInt8(_tag.Handle, offset);
 
     /// <summary>Set bit from index and value.</summary>
     /// <param name="index">The index.</param>
@@ -143,9 +157,9 @@ public class PlcTagWrapper
     public void SetBit(int index, bool value)
     {
 #if NET8_0_OR_GREATER
-        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _tag.Size * 8);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _tag.Size * BitsPerByte);
 #else
-        if (_tag.Size * 8 <= index)
+        if (_tag.Size * BitsPerByte <= index)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
         }
@@ -186,32 +200,32 @@ public class PlcTagWrapper
     /// <summary>Set local value Float32.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetFloat32(float value, int offset = 0) => plctag.plc_tag_set_float32(_tag.Handle, offset, value);
+    public void SetFloat32(float value, int offset = 0) => _native.SetFloat32(_tag.Handle, offset, value);
 
     /// <summary>Set local value Float.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetFloat64(double value, int offset = 0) => plctag.plc_tag_set_float64(_tag.Handle, offset, value);
+    public void SetFloat64(double value, int offset = 0) => _native.SetFloat64(_tag.Handle, offset, value);
 
     /// <summary>Set local value Int16.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetInt16(short value, int offset = 0) => plctag.plc_tag_set_int16(_tag.Handle, offset, value);
+    public void SetInt16(short value, int offset = 0) => _native.SetInt16(_tag.Handle, offset, value);
 
     /// <summary>Set local value Int32.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetInt32(int value, int offset = 0) => plctag.plc_tag_set_int32(_tag.Handle, offset, value);
+    public void SetInt32(int value, int offset = 0) => _native.SetInt32(_tag.Handle, offset, value);
 
     /// <summary>Set local value Int64.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetInt64(long value, int offset = 0) => plctag.plc_tag_set_int64(_tag.Handle, offset, value);
+    public void SetInt64(long value, int offset = 0) => _native.SetInt64(_tag.Handle, offset, value);
 
     /// <summary>Set local value Int8.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetInt8(sbyte value, int offset = 0) => plctag.plc_tag_set_int8(_tag.Handle, offset, value);
+    public void SetInt8(sbyte value, int offset = 0) => _native.SetInt8(_tag.Handle, offset, value);
 
     /// <summary>Set local value String.</summary>
     /// <param name="value">The value.</param>
@@ -266,22 +280,22 @@ public class PlcTagWrapper
     /// <summary>Set local value UInt16.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetUInt16(ushort value, int offset = 0) => plctag.plc_tag_set_uint16(_tag.Handle, offset, value);
+    public void SetUInt16(ushort value, int offset = 0) => _native.SetUInt16(_tag.Handle, offset, value);
 
     /// <summary>Set local value UInt32.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetUInt32(uint value, int offset = 0) => plctag.plc_tag_set_uint32(_tag.Handle, offset, value);
+    public void SetUInt32(uint value, int offset = 0) => _native.SetUInt32(_tag.Handle, offset, value);
 
     /// <summary>Set local value UInt64.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetUInt64(ulong value, int offset = 0) => plctag.plc_tag_set_uint64(_tag.Handle, offset, value);
+    public void SetUInt64(ulong value, int offset = 0) => _native.SetUInt64(_tag.Handle, offset, value);
 
     /// <summary>Set local value UInt8.</summary>
     /// <param name="value">The value.</param>
     /// <param name="offset">The offset.</param>
-    public void SetUInt8(byte value, int offset = 0) => plctag.plc_tag_set_uint8(_tag.Handle, offset, value);
+    public void SetUInt8(byte value, int offset = 0) => _native.SetUInt8(_tag.Handle, offset, value);
 
     /// <summary>Get local value.</summary>
     /// <param name="obj">The object.</param>

--- a/src/ABPlcRx/Core/PlcType.cs
+++ b/src/ABPlcRx/Core/PlcType.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Allen Bradley PLC processor family.</summary>
 public enum PlcType

--- a/src/ABPlcRx/Core/TagHelper.cs
+++ b/src/ABPlcRx/Core/TagHelper.cs
@@ -5,7 +5,11 @@
 using System.Collections;
 using System.Reflection;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Helper Tag.</summary>
 public static class TagHelper

--- a/src/ABPlcRx/Core/TagMixins.cs
+++ b/src/ABPlcRx/Core/TagMixins.cs
@@ -4,7 +4,11 @@
 
 using System.Collections;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>PLC tag bit helper extensions.</summary>
 public static class TagMixins

--- a/src/ABPlcRx/IABPlcRx.cs
+++ b/src/ABPlcRx/IABPlcRx.cs
@@ -5,12 +5,18 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+#if !REACTIVE_SHIM
 using ReactiveUI.Primitives.Concurrency;
+#endif
 #if NET8_0_OR_GREATER
 using ReactiveUI.Primitives.Async;
 #endif
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Reactive Allen Bradley PLC facade contract.</summary>
 /// <seealso cref="IDisposable" />

--- a/src/ABPlcRx/IABPlcRx.cs
+++ b/src/ABPlcRx/IABPlcRx.cs
@@ -2,16 +2,6 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-#if !REACTIVE_SHIM
-using ReactiveUI.Primitives.Concurrency;
-#endif
-#if NET8_0_OR_GREATER
-using ReactiveUI.Primitives.Async;
-#endif
-
 #if REACTIVELIST_REACTIVE
 namespace ABPlcRx.Reactive;
 #else
@@ -31,13 +21,11 @@ public interface IABPlcRx : IDisposable
     /// </value>
     IObservable<IPlcTag?> ObserveAll { get; }
 
-#if NET8_0_OR_GREATER
     /// <summary>Gets the asynchronous observe all stream.</summary>
     /// <value>
     /// The asynchronous observe all stream.
     /// </value>
     IObservableAsync<IPlcTag?> ObserveAllAsyncObservable { get; }
-#endif
 
     /// <summary>Gets or sets a value indicating whether [scan enabled].</summary>
     /// <value>

--- a/src/ABPlcRx/ObservableAsyncBridgeExtensions.cs
+++ b/src/ABPlcRx/ObservableAsyncBridgeExtensions.cs
@@ -5,7 +5,11 @@
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Async;
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive;
+#else
 namespace ABPlcRx;
+#endif
 
 /// <summary>Bridges synchronous observable streams to ReactiveUI.Primitives async observables.</summary>
 public static class ObservableAsyncBridgeExtensions

--- a/src/ABPlcRx/ObservableAsyncBridgeExtensions.cs
+++ b/src/ABPlcRx/ObservableAsyncBridgeExtensions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) 2022-2026 Chris Pulman. All rights reserved.
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Async;
+using PrimitivesResult = ReactiveUI.Primitives.Result;
 
 #if REACTIVELIST_REACTIVE
 namespace ABPlcRx.Reactive;
@@ -20,7 +18,14 @@ public static class ObservableAsyncBridgeExtensions
     /// <returns>An async observable that forwards source notifications.</returns>
     public static IObservableAsync<T> ToAsyncObservable<T>(IObservable<T> source)
     {
+#if NET8_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(source);
+#else
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+#endif
         return new ObservableAsyncAdapter<T>(source);
     }
 
@@ -51,7 +56,7 @@ public static class ObservableAsyncBridgeExtensions
     {
         /// <summary>Forwards completion to the async observer.</summary>
         public void OnCompleted() =>
-            observer.OnCompletedAsync(Result.Success).AsTask().GetAwaiter().GetResult();
+            observer.OnCompletedAsync(PrimitivesResult.Success).AsTask().GetAwaiter().GetResult();
 
         /// <summary>Forwards errors to the async observer.</summary>
         /// <param name="error">The observed error.</param>
@@ -77,4 +82,3 @@ public static class ObservableAsyncBridgeExtensions
         }
     }
 }
-#endif

--- a/src/ABPlcRx/SourceGeneration/PlcModelAttribute.cs
+++ b/src/ABPlcRx/SourceGeneration/PlcModelAttribute.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive.SourceGeneration;
+#else
 namespace ABPlcRx.SourceGeneration;
+#endif
 
 /// <summary>Marks a partial type as a PLC reactive stream model.</summary>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/ABPlcRx/SourceGeneration/PlcTagAttribute.cs
+++ b/src/ABPlcRx/SourceGeneration/PlcTagAttribute.cs
@@ -2,7 +2,11 @@
 // Chris Pulman licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if REACTIVELIST_REACTIVE
+namespace ABPlcRx.Reactive.SourceGeneration;
+#else
 namespace ABPlcRx.SourceGeneration;
+#endif
 
 /// <summary>Describes a PLC tag stream that should be generated for a partial model.</summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/migration: adds the `ABPlcRx.Reactive` shared-source package and updates the existing library/source generator/test suite for ReactiveUI.Primitives 6.0.0 reactive variants.

## What is the new behavior?

- `ABPlcRx.Reactive` builds from the shared `ABPlcRx` sources with `REACTIVE_SHIM` and `REACTIVELIST_REACTIVE` defined.
- Shared source now emits `ABPlcRx.Reactive.*` namespaces for the reactive build and `ABPlcRx.*` for the base build.
- Source generation supports both `ABPlcRx.SourceGeneration` and `ABPlcRx.Reactive.SourceGeneration` attributes.
- Native PLC calls are behind an internal adapter seam so PLC/tag behavior can be tested without PLC hardware.
- `PlcTagCollection` snapshots tag lists under lock to avoid scan/read races while tags are removed.

## What is the current behavior?

- Only the base `ABPlcRx` package is built.
- The source generator only targets the base `ABPlcRx` runtime namespace.
- Tag/native behavior is harder to test without real native IO, and tag scans can race with tag removal.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Verification completed:

- `dotnet build src\\ABPlcRx.slnx -c Release -v minimal /m:1` passed with 0 warnings and 0 errors.
- `dotnet test src\\ABPlcRx.Tests\\ABPlcRx.Tests.csproj -c Release --no-build -v minimal` passed: 123 tests, 0 failed.
- `dotnet test src\\ABPlcRx.Tests\\ABPlcRx.Tests.csproj -c Release --no-build -v minimal -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml` passed.

Coverage is scoped to `ABPlcRx`, `ABPlcRx.Reactive`, and `ABPlcRx.SourceGenerators`; current merged MTP summary is 61.58% line and 50.65% branch. On the net8 report: `ABPlcRx` is 75.35% line, `ABPlcRx.Reactive` is 35.30% line, and `ABPlcRx.SourceGenerators` is 99.25% line. No coverage suppressions were added.